### PR TITLE
Base structure for unit tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
-            "program": "${workspaceRoot}/src/core/Piranha.Manager/bin/Debug/netcoreapp1.0/Piranha.Manager.dll",
+            "program": "${workspaceRoot}/src/core/Piranha.Manager/bin/Debug/netcoreapp1.1/Piranha.Manager.dll",
             "args": [],
             "cwd": "${workspaceRoot}",
             "stopAtEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,10 @@
             "request": "launch",
             "preLaunchTask": "build",
             "program": "${workspaceRoot}/src/core/Piranha.Manager/bin/Debug/netcoreapp1.1/Piranha.Manager.dll",
+            // "program": "${workspaceRoot}/src/examples/Blog/bin/Debug/netcoreapp1.1/Blog.dll",
             "args": [],
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceRoot}/src/core/Piranha.Manager",
+            // "cwd": "${workspaceRoot}/src/examples/Blog",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart",
             "launchBrowser": {

--- a/global.json
+++ b/global.json
@@ -1,5 +1,16 @@
 {
-  "projects": [ "src", "src/core", "src/data", "src/env", "src/examples" ],
+  "projects": [ 
+    "src",
+    "src/core",
+    "src/data",
+    "src/env",
+    "src/examples", 
+    "test",
+    "test/core",
+    "test/data",
+    "test/env",
+    "test/examples"
+  ],
   "sdk": {
     "version": "1.1.0"
   }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockController.cs
@@ -14,29 +14,22 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace Piranha.Areas.Manager.Controllers
 {
-    [Area("Manager")]
-    public class BlockController : Controller
+    public class BlockController : ManagerAreaControllerBase
     {
-        #region Members
-        /// <summary>
-        /// The current api.
-        /// </summary>
-        private IApi api;
-        #endregion
-
         /// <summary>
         /// Default constroller.
         /// </summary>
         /// <param name="api">The current api</param>
-        public BlockController(IApi api) {
-            this.api = api;
+        public BlockController(IApi api) : base(api)
+        {
         }
 
         /// <summary>
         /// Gets the list view for the blocks.
         /// </summary>
         [Route("manager/blocks")]
-        public IActionResult List() {
+        public IActionResult List()
+        {
             return View();
         }
     }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockController.cs
@@ -28,7 +28,7 @@ namespace Piranha.Areas.Manager.Controllers
         /// Gets the list view for the blocks.
         /// </summary>
         [Route("manager/blocks")]
-        public IActionResult List()
+        public ViewResult List()
         {
             return View();
         }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockTypeController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockTypeController.cs
@@ -27,7 +27,7 @@ namespace Piranha.Areas.Manager.Controllers
         /// Gets the list view for the block types.
         /// </summary>
         [Route("manager/blocktypes")]
-        public IActionResult List() {
+        public ViewResult List() {
             return View(App.BlockTypes);
         }
 
@@ -36,7 +36,7 @@ namespace Piranha.Areas.Manager.Controllers
         /// Gets the edit view for the specified block type.
         /// </summary>
         [Route("manager/blocktype/{id}")]
-        public IActionResult Edit(string id) {
+        public ViewResult Edit(string id) {
             return View(App.BlockTypes.SingleOrDefault(t => t.Id.ToLower() == id.ToLower()));
         }
     }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockTypeController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/BlockTypeController.cs
@@ -13,22 +13,14 @@ using System.Linq;
 
 namespace Piranha.Areas.Manager.Controllers
 {
-    [Area("Manager")]
-    public class BlockTypeController : Controller
+    public class BlockTypeController : ManagerAreaControllerBase
     {
-        #region Members
-        /// <summary>
-        /// The current api.
-        /// </summary>
-        private IApi api;
-        #endregion
-
         /// <summary>
         /// Default constructor.
         /// </summary>
         /// <param name="api">The current api</param>
-        public BlockTypeController(IApi api) {
-            this.api = api;
+        public BlockTypeController(IApi api) : base(api)
+        {
         }
 
         /// <summary>

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/ManagerAreaControllerBase.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/ManagerAreaControllerBase.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Piranha.Areas.Manager.Controllers
+{
+    [Area("manager")]
+    public class ManagerAreaControllerBase : Controller
+    {
+        #region Properties
+        #region Protected Properties
+        /// <summary>
+        /// The current api
+        /// </summary>
+        protected readonly IApi _api;
+        #endregion
+        #endregion
+
+        public ManagerAreaControllerBase(IApi api)
+        {
+            _api = api;
+        }
+    }
+}

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/PageController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/PageController.cs
@@ -27,7 +27,7 @@ namespace Piranha.Areas.Manager.Controllers
         /// Gets the list view for the pages.
         /// </summary>
         [Route("manager/pages")]
-        public IActionResult List()
+        public ViewResult List()
         {
             return View(Models.PageListModel.Get(_api));
         }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/PageController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/PageController.cs
@@ -13,30 +13,23 @@ using System;
 
 namespace Piranha.Areas.Manager.Controllers
 {
-    [Area("Manager")]
-    public class PageController : Controller
+    public class PageController : ManagerAreaControllerBase
     {
-        #region Members
-        /// <summary>
-        /// The current api.
-        /// </summary>
-        private readonly IApi api;
-        #endregion
-
         /// <summary>
         /// Default constructor.
         /// </summary>
         /// <param name="api">The current api</param>
-        public PageController(IApi api) {
-            this.api = api;
+        public PageController(IApi api) : base(api)
+        {
         }
 
         /// <summary>
         /// Gets the list view for the pages.
         /// </summary>
         [Route("manager/pages")]
-        public IActionResult List() {
-            return View(Models.PageListModel.Get(api));
+        public IActionResult List()
+        {
+            return View(Models.PageListModel.Get(_api));
         }
 
         /// <summary>
@@ -44,8 +37,9 @@ namespace Piranha.Areas.Manager.Controllers
         /// </summary>
         /// <param name="id">The page id</param>
         [Route("manager/page/{id:Guid}")]
-        public IActionResult Edit(Guid id) {
-            return View(Models.PageEditModel.GetById(api, id));
+        public IActionResult Edit(Guid id)
+        {
+            return View(Models.PageEditModel.GetById(_api, id));
         }
 
         /// <summary>
@@ -53,8 +47,9 @@ namespace Piranha.Areas.Manager.Controllers
         /// </summary>
         /// <param name="type">The page type id</param>
         [Route("manager/page/add/{type}")]
-        public IActionResult Add(string type) {
-            var sitemap = api.Sitemap.Get(false);
+        public IActionResult Add(string type)
+        {
+            var sitemap = _api.Sitemap.Get(false);
             var model = Models.PageEditModel.Create(type);
             model.SortOrder = sitemap.Count;
 
@@ -68,8 +63,9 @@ namespace Piranha.Areas.Manager.Controllers
         [HttpPost]
         //[ValidateAntiForgeryToken] Seems buggy ATM
         [Route("manager/page/save")]
-        public IActionResult Save(Models.PageEditModel model) {
-            if (model.Save(api))
+        public IActionResult Save(Models.PageEditModel model)
+        {
+            if (model.Save(_api))
                 return RedirectToAction("List");
             return View(model);
         }
@@ -81,8 +77,9 @@ namespace Piranha.Areas.Manager.Controllers
         [HttpPost]
         //[ValidateAntiForgeryToken] Seems buggy ATM
         [Route("manager/page/publish")]
-        public IActionResult Publish(Models.PageEditModel model) {
-            if (model.Save(api, true))
+        public IActionResult Publish(Models.PageEditModel model)
+        {
+            if (model.Save(_api, true))
                 return RedirectToAction("List");
             return View(model);
         }
@@ -94,8 +91,9 @@ namespace Piranha.Areas.Manager.Controllers
         [HttpPost]
         //[ValidateAntiForgeryToken] Seems buggy ATM
         [Route("manager/page/unpublish")]
-        public IActionResult UnPublish(Models.PageEditModel model) {
-            if (model.Save(api, false))
+        public IActionResult UnPublish(Models.PageEditModel model)
+        {
+            if (model.Save(_api, false))
                 return RedirectToAction("List");
             return View(model);
         }
@@ -106,13 +104,15 @@ namespace Piranha.Areas.Manager.Controllers
         /// <param name="structure">The page structure</param>
         [HttpPost]
         [Route("manager/pages/move")]
-        public IActionResult Move([FromBody]Models.PageStructureModel structure) {
-            for (var n = 0; n < structure.Items.Count; n++) {
+        public IActionResult Move([FromBody]Models.PageStructureModel structure)
+        {
+            for (var n = 0; n < structure.Items.Count; n++)
+            {
                 var moved = MovePage(structure.Items[n], n);
                 if (moved)
                     break;
             }
-            return View("Partial/_Sitemap", api.Sitemap.Get(false));
+            return View("Partial/_Sitemap", _api.Sitemap.Get(false));
         }
 
         /// <summary>
@@ -120,25 +120,30 @@ namespace Piranha.Areas.Manager.Controllers
         /// </summary>
         /// <param name="id">The unique id</param>
         [Route("manager/page/delete/{id:Guid}")]
-        public IActionResult Delete(Guid id) {
-            api.Pages.Delete(id);
+        public IActionResult Delete(Guid id)
+        {
+            _api.Pages.Delete(id);
             return RedirectToAction("List");
-        }        
+        }
 
         #region Private methods
-        private bool MovePage(Models.PageStructureModel.PageStructureItem page, int sortOrder = 1, Guid? parentId = null) {
-            var model = api.Pages.GetById(page.Id);
+        private bool MovePage(Models.PageStructureModel.PageStructureItem page, int sortOrder = 1, Guid? parentId = null)
+        {
+            var model = _api.Pages.GetById(page.Id);
 
-            if (model != null) {
-                if (model.ParentId != parentId || model.SortOrder != sortOrder) {
+            if (model != null)
+            {
+                if (model.ParentId != parentId || model.SortOrder != sortOrder)
+                {
                     // Move the page in the structure.
-                    api.Pages.Move(model, parentId, sortOrder);
+                    _api.Pages.Move(model, parentId, sortOrder);
 
                     // We only move one page at a time so we're done
                     return true;
                 }
 
-                for (var n = 0; n < page.Children.Count; n++) {
+                for (var n = 0; n < page.Children.Count; n++)
+                {
                     var moved = MovePage(page.Children[n], n, page.Id);
 
                     if (moved)

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/PageTypeController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/PageTypeController.cs
@@ -14,28 +14,22 @@ using System.Linq;
 namespace Piranha.Areas.Manager.Controllers
 {
     [Area("Manager")]
-    public class PageTypeController : Controller
+    public class PageTypeController : ManagerAreaControllerBase
     {
-        #region Members
-        /// <summary>
-        /// The current api.
-        /// </summary>
-        private IApi api;
-        #endregion
-
         /// <summary>
         /// Default constructor.
         /// </summary>
         /// <param name="api">The current api</param>
-        public PageTypeController(IApi api) {
-            this.api = api;
+        public PageTypeController(IApi api) : base(api)
+        {
         }
 
         /// <summary>
         /// Gets the list view for the page types.
         /// </summary>
         [Route("manager/pagetypes")]
-        public IActionResult List() {
+        public IActionResult List()
+        {
             return View(App.PageTypes);
         }
 
@@ -43,7 +37,8 @@ namespace Piranha.Areas.Manager.Controllers
         /// Gets the edit view for the specified page type.
         /// </summary>
         [Route("manager/pagetype/{id}")]
-        public IActionResult Edit(string id) {
+        public IActionResult Edit(string id)
+        {
             return View(App.PageTypes.SingleOrDefault(t => t.Id.ToLower() == id.ToLower()));
         }
     }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/PostController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/PostController.cs
@@ -13,28 +13,22 @@ using Microsoft.AspNetCore.Mvc;
 namespace Piranha.Areas.Manager.Controllers
 {
     [Area("Manager")]
-    public class PostController : Controller
+    public class PostController : ManagerAreaControllerBase
     {
-        #region Members
-        /// <summary>
-        /// The current api.
-        /// </summary>
-        private IApi api;
-        #endregion
-
         /// <summary>
         /// Default constroller.
         /// </summary>
         /// <param name="api">The current api</param>
-        public PostController(IApi api) {
-            this.api = api;
+        public PostController(IApi api) : base(api)
+        {
         }
 
         /// <summary>
         /// Gets the list view for the posts.
         /// </summary>
         [Route("manager/posts")]
-        public IActionResult List() {
+        public IActionResult List()
+        {
             return View();
         }
     }

--- a/src/core/Piranha.Manager/Manager/ResourceMiddleware.cs
+++ b/src/core/Piranha.Manager/Manager/ResourceMiddleware.cs
@@ -87,7 +87,7 @@ namespace Piranha.Manager
         /// <returns>The content type</returns>
         private string GetContentType(string path) {
             try {
-                return contentTypes[path.Substring(path.LastIndexOf("."))];
+                return contentTypes[Path.GetExtension(path)];
             } catch { }
             return "text/plain";
         }

--- a/src/core/Piranha.Manager/project.json
+++ b/src/core/Piranha.Manager/project.json
@@ -22,7 +22,8 @@
     "Microsoft.Extensions.Logging.Console": "1.1.0",
     "Piranha.AspNet": "4.0.0-*",
     "Piranha.Core": "4.0.0-*",
-    "Piranha.EF": "4.0.0-*"
+    "Piranha.EF": "4.0.0-*",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.0"
   },
 
   "tools": {

--- a/test/core/Piranha.AspNet.Tests/Class1.cs
+++ b/test/core/Piranha.AspNet.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.AspNet.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/core/Piranha.AspNet.Tests/project.json
+++ b/test/core/Piranha.AspNet.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.AspNet.Tests/project.json
+++ b/test/core/Piranha.AspNet.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Piranha.AspNet": "4.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.AspNet.Tests/project.json
+++ b/test/core/Piranha.AspNet.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.AspNet.Tests"
+    }
+}

--- a/test/core/Piranha.AspNet.Tests/xunit.runner.json
+++ b/test/core/Piranha.AspNet.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/core/Piranha.Builder.Attribute.Tests/Class1.cs
+++ b/test/core/Piranha.Builder.Attribute.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.Builder.Attribute.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/core/Piranha.Builder.Attribute.Tests/project.json
+++ b/test/core/Piranha.Builder.Attribute.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Builder.Attribute.Tests/project.json
+++ b/test/core/Piranha.Builder.Attribute.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Piranha.Builder.Attribute": "4.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Builder.Attribute.Tests/project.json
+++ b/test/core/Piranha.Builder.Attribute.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.Builder.Attribute.Tests"
+    }
+}

--- a/test/core/Piranha.Builder.Attribute.Tests/xunit.runner.json
+++ b/test/core/Piranha.Builder.Attribute.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/core/Piranha.Builder.Json.Tests/Class1.cs
+++ b/test/core/Piranha.Builder.Json.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.Builder.Json.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/core/Piranha.Builder.Json.Tests/project.json
+++ b/test/core/Piranha.Builder.Json.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Builder.Json.Tests/project.json
+++ b/test/core/Piranha.Builder.Json.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.Builder.Json.Tests"
+    }
+}

--- a/test/core/Piranha.Builder.Json.Tests/project.json
+++ b/test/core/Piranha.Builder.Json.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Piranha.Builder.Json": "4.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Builder.Json.Tests/xunit.runner.json
+++ b/test/core/Piranha.Builder.Json.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/core/Piranha.Core.Tests/Class1.cs
+++ b/test/core/Piranha.Core.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.Core.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/core/Piranha.Core.Tests/project.json
+++ b/test/core/Piranha.Core.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Core.Tests/project.json
+++ b/test/core/Piranha.Core.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.Core.Tests"
+    }
+}

--- a/test/core/Piranha.Core.Tests/project.json
+++ b/test/core/Piranha.Core.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Piranha.Core": "4.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Core.Tests/xunit.runner.json
+++ b/test/core/Piranha.Core.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockControllerUnitTest.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Piranha.Areas.Manager.Controllers;
+using Xunit;
+
+namespace Piranha.Manager.Tests.Areas.Manager.Controllers
+{
+    public class BlockControllerUnitTest : ManagerAreaControllerUnitTestBase<BlockController>
+    {
+        [Fact]
+        public void ListViewResultIsNotNull()
+        {
+            #region Arrange
+            #endregion
+
+            #region Act
+            ViewResult result = _controller.List() as ViewResult;
+            #endregion
+
+            #region Assert
+            Assert.NotNull(result);
+            #endregion
+        }
+
+        protected override BlockController SetupController()
+        {
+            return new BlockController(_api.Object);
+        }
+    }
+}

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockControllerUnitTest.cs
@@ -7,6 +7,11 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
 {
     public class BlockControllerUnitTest : ManagerAreaControllerUnitTestBase<BlockController>
     {
+        protected override BlockController SetupController()
+        {
+            return new BlockController(_api.Object);
+        }
+
         [Fact]
         public void ListViewResultIsNotNull()
         {
@@ -20,11 +25,6 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             #region Assert
             Assert.NotNull(result);
             #endregion
-        }
-
-        protected override BlockController SetupController()
-        {
-            return new BlockController(_api.Object);
         }
     }
 }

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockTypeControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockTypeControllerUnitTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc;
+using Piranha.Areas.Manager.Controllers;
+using Piranha.Extend;
+using Xunit;
+
+namespace Piranha.Manager.Tests.Areas.Manager.Controllers
+{
+    public class BlockTypeControllerUnitTest : ManagerAreaControllerUnitTestBase<BlockTypeController>
+    {
+        protected override BlockTypeController SetupController()
+        {
+            return new BlockTypeController(_api.Object);
+        }
+
+        [Fact]
+        public void ListResultIsNotNull()
+        {
+            #region Arrange
+            #endregion
+
+            #region Act
+            ViewResult result = _controller.List() as ViewResult;
+            #endregion
+
+            #region Assert
+            Assert.NotNull(result);
+            IList<BlockType> Model = result.Model as IList<BlockType>;
+            Assert.NotNull(Model);
+            #endregion
+        }
+
+        [Fact]
+        public void EditResultWithEmptyApiProduces()
+        {
+            #region Arrange
+            #endregion
+
+            #region Act
+            ViewResult result = _controller.Edit("no-id") as ViewResult;
+            #endregion
+
+            #region Assert
+            Assert.NotNull(result);
+            BlockType Model = result.Model as BlockType;
+            Assert.Null(Model);
+            #endregion
+        }
+    }
+}

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockTypeControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/BlockTypeControllerUnitTest.cs
@@ -21,7 +21,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             #endregion
 
             #region Act
-            ViewResult result = _controller.List() as ViewResult;
+            ViewResult result = _controller.List();
             #endregion
 
             #region Assert
@@ -38,7 +38,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             #endregion
 
             #region Act
-            ViewResult result = _controller.Edit("no-id") as ViewResult;
+            ViewResult result = _controller.Edit("no-id");
             #endregion
 
             #region Assert

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
@@ -26,10 +26,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             return new Mock<IApi>();
         }
 
-        protected virtual TController SetupController()
-        {
-            return new ManagerAreaControllerBase(_api.Object) as TController;
-        }
+        protected abstract TController SetupController();
         #endregion
     }
 }

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
@@ -1,10 +1,35 @@
 using Piranha.Areas.Manager.Controllers;
+using Moq;
 
 namespace Piranha.Manager.Tests.Areas.Manager.Controllers
 {
     public abstract class ManagerAreaControllerUnitTestBase<TController>
         where TController : ManagerAreaControllerBase
     {
-        
+        #region Properties
+        #region Protected Properties
+        protected readonly TController _controller;
+
+        protected readonly Mock<IApi> _api;
+        #endregion
+        #endregion
+
+        #region Test initialize
+        public ManagerAreaControllerUnitTestBase()
+        {
+            _api = SetupApi();
+            _controller = SetupController();
+        }
+
+        protected virtual Mock<IApi> SetupApi()
+        {
+            return new Mock<IApi>();
+        }
+
+        protected virtual TController SetupController()
+        {
+            return new ManagerAreaControllerBase(_api.Object) as TController;
+        }
+        #endregion
     }
 }

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
@@ -1,0 +1,10 @@
+using Piranha.Areas.Manager.Controllers;
+
+namespace Piranha.Manager.Tests.Areas.Manager.Controllers
+{
+    public abstract class ManagerAreaControllerUnitTestBase<TController>
+        where TController : ManagerAreaControllerBase
+    {
+        
+    }
+}

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Piranha.Areas.Manager.Controllers;
+using Piranha.Areas.Manager.Models;
+using Piranha.Models;
+using Xunit;
+
+namespace Piranha.Manager.Tests.Areas.Manager.Controllers
+{
+    public class PageControllerUnitTest : ManagerAreaControllerUnitTestBase<PageController>
+    {
+        protected override PageController SetupController()
+        {
+            return new PageController(_api.Object);
+        }
+
+        [Fact]
+        public void ListResultIsNotNull()
+        {
+            #region Arrange
+            _api.Setup(a => a.Sitemap.Get(false)).Returns(new List<SitemapItem>());
+            #endregion
+
+            #region Act
+            ViewResult result = _controller.List();
+            #endregion
+
+            #region Assert
+            Assert.NotNull(result);
+            PageListModel Model = result.Model as PageListModel;
+            Assert.NotNull(Model);
+            #endregion
+        }
+    }
+}

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageTypeControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageTypeControllerUnitTest.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Piranha.Areas.Manager.Controllers;
+
+namespace Piranha.Manager.Tests.Areas.Manager.Controllers
+{
+    public class PageTypeControllerUnitTest : ManagerAreaControllerUnitTestBase<PageTypeController>
+    {
+        protected override PageTypeController SetupController()
+        {
+            return new PageTypeController(_api.Object);
+        }
+    }
+}

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PostControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PostControllerUnitTest.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Piranha.Areas.Manager.Controllers;
+
+namespace Piranha.Manager.Tests.Areas.Manager.Controllers
+{
+    public class PostControllerUnitTest : ManagerAreaControllerUnitTestBase<PostController>
+    {
+        protected override PostController SetupController()
+        {
+            return new PostController(_api.Object);
+        }
+    }
+}

--- a/test/core/Piranha.Manager.Tests/Class1.cs
+++ b/test/core/Piranha.Manager.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.Manager.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/core/Piranha.Manager.Tests/project.json
+++ b/test/core/Piranha.Manager.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Manager.Tests/project.json
+++ b/test/core/Piranha.Manager.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Piranha.Manager": "4.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/core/Piranha.Manager.Tests/project.json
+++ b/test/core/Piranha.Manager.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.Manager.Tests"
+    }
+}

--- a/test/core/Piranha.Manager.Tests/xunit.runner.json
+++ b/test/core/Piranha.Manager.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/data/Piranha.EF.Tests/Class1.cs
+++ b/test/data/Piranha.EF.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.EF.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/data/Piranha.EF.Tests/project.json
+++ b/test/data/Piranha.EF.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/data/Piranha.EF.Tests/project.json
+++ b/test/data/Piranha.EF.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Piranha.EF": "4.0.0-*",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/data/Piranha.EF.Tests/project.json
+++ b/test/data/Piranha.EF.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.EF.Tests"
+    }
+}

--- a/test/data/Piranha.EF.Tests/xunit.runner.json
+++ b/test/data/Piranha.EF.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/env/Piranha.Azure.Tests/Class1.cs
+++ b/test/env/Piranha.Azure.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Piranha.Azure.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/env/Piranha.Azure.Tests/project.json
+++ b/test/env/Piranha.Azure.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/env/Piranha.Azure.Tests/project.json
+++ b/test/env/Piranha.Azure.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Piranha.Azure.Tests"
+    }
+}

--- a/test/env/Piranha.Azure.Tests/xunit.runner.json
+++ b/test/env/Piranha.Azure.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}

--- a/test/examples/Blog.Tests/Class1.cs
+++ b/test/examples/Blog.Tests/Class1.cs
@@ -1,0 +1,26 @@
+using Xunit;
+
+namespace Blog.Tests
+{
+    // see example explanation on xUnit.net website:
+    // https://xunit.github.io/docs/getting-started-dotnet-core.html
+    public class Class1
+    {
+        [Fact]
+        public void PassingTest()
+        {
+            Assert.Equal(4, Add(2, 2));
+        }
+
+        [Fact]
+        public void FailingTest()
+        {
+            Assert.Equal(5, Add(2, 2));
+        }
+
+        int Add(int x, int y)
+        {
+            return x + y;
+        }
+    }
+}

--- a/test/examples/Blog.Tests/project.json
+++ b/test/examples/Blog.Tests/project.json
@@ -3,7 +3,8 @@
     "testRunner": "xunit",
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
-        "xunit": "2.2.0-beta2-build3300"
+        "xunit": "2.2.0-beta2-build3300",
+        "Moq": "4.6.38-alpha"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/examples/Blog.Tests/project.json
+++ b/test/examples/Blog.Tests/project.json
@@ -4,7 +4,9 @@
     "dependencies": {
         "dotnet-test-xunit": "2.2.0-preview2-build1029",
         "xunit": "2.2.0-beta2-build3300",
-        "Moq": "4.6.38-alpha"
+        "Moq": "4.6.38-alpha",
+        "Blog": "1.0.0",
+        "Microsoft.DotNet.InternalAbstractions": "1.0.0"
     },
     "frameworks": {
         "netcoreapp1.1": {

--- a/test/examples/Blog.Tests/project.json
+++ b/test/examples/Blog.Tests/project.json
@@ -1,0 +1,26 @@
+{
+    "version": "1.0.0-*",
+    "testRunner": "xunit",
+    "dependencies": {
+        "dotnet-test-xunit": "2.2.0-preview2-build1029",
+        "xunit": "2.2.0-beta2-build3300"
+    },
+    "frameworks": {
+        "netcoreapp1.1": {
+            "dependencies": {
+                "Microsoft.NETCore.App": {
+                    "type": "platform",
+                    "version": "1.1.0"
+                }
+            }
+        }
+    },
+    "buildOptions": {
+        "copyToOutput": {
+            "include": [ "xunit.runner.json" ]
+        }
+    },
+    "tooling": {
+        "defaultNamespace": "Blog.Tests"
+    }
+}

--- a/test/examples/Blog.Tests/xunit.runner.json
+++ b/test/examples/Blog.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+    "diagnosticMessages": false,
+    "methodDisplay": "classAndMethod",
+    "parallelizeTestCollections": true
+}


### PR DESCRIPTION
Created the basic folder structure for unit testing piranha.core, including xUnit for unit testing for all applications. Still a dependency issue with `Piranha.Azure` at this point so this will need to be looked into.

Focused on a simple framework for unit testing the `Piranha.Manager` controllers, with a few sample unit tests for the controllers. Still need a better understanding of how the controllers are designed before delving in further with more tests