### PR TITLE
Piranha.Manager.Tests

### DIFF
--- a/src/core/Piranha.Core/Models/Page.cs
+++ b/src/core/Piranha.Core/Models/Page.cs
@@ -32,8 +32,8 @@ namespace Piranha.Models
         /// </summary>
         /// <param name="typeId">The unique page type id</param>
         /// <returns>The new model</returns>
-        public static T Create(string typeId) {
-            using (var factory = new ContentFactory(App.PageTypes)) {
+        public static T Create(IApi api, string typeId) {
+            using (var factory = new ContentFactory(api.PageTypes.Get())) {
                 return factory.Create<T>(typeId);
             }
         }

--- a/src/core/Piranha.Manager/Areas/Manager/Controllers/PageController.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Controllers/PageController.cs
@@ -46,7 +46,7 @@ namespace Piranha.Areas.Manager.Controllers
         [Route("manager/page/add/{type}")]
         public IActionResult Add(string type) {
             var sitemap = api.Sitemap.Get(false);
-            var model = Models.PageEditModel.Create(type);
+            var model = Models.PageEditModel.Create(api, type);
             model.SortOrder = sitemap.Count;
 
             return View("Edit", model);

--- a/src/core/Piranha.Manager/Areas/Manager/Models/PageEditModel.cs
+++ b/src/core/Piranha.Manager/Areas/Manager/Models/PageEditModel.cs
@@ -50,7 +50,7 @@ namespace Piranha.Areas.Manager.Models
             var page = api.Pages.GetById(Id);
 
             if (page == null)
-                page = Piranha.Models.DynamicPage.Create(this.TypeId);
+                page = Piranha.Models.DynamicPage.Create(api, this.TypeId);
 
             Module.Mapper.Map<PageEditModel, Piranha.Models.PageBase>(this, page);
             SaveRegions(this, page);
@@ -89,11 +89,11 @@ namespace Piranha.Areas.Manager.Models
         /// </summary>
         /// <param name="pageTypeId">The page type id</param>
         /// <returns>The page model</returns>        
-        public static PageEditModel Create(string pageTypeId) {
-            var type = App.PageTypes.SingleOrDefault(t => t.Id == pageTypeId);
+        public static PageEditModel Create(IApi api, string pageTypeId) {
+            var type = api.PageTypes.GetById(pageTypeId);
 
             if (type != null) {
-                var page = Piranha.Models.DynamicPage.Create(pageTypeId);
+                var page = Piranha.Models.DynamicPage.Create(api, pageTypeId);
                 var model = Module.Mapper.Map<Piranha.Models.PageBase, PageEditModel>(page);
                 model.PageType = type;
                 LoadRegions(page, model);

--- a/src/data/Piranha.EF/Module.cs
+++ b/src/data/Piranha.EF/Module.cs
@@ -19,6 +19,9 @@ namespace Piranha.EF
     /// </summary>
     public class Module : Extend.IModule
     {
+        private static bool isInitialized = false;
+        private static readonly object mutex = new object();
+
         /// <summary>
         /// Gets the mapper.
         /// </summary>
@@ -38,54 +41,61 @@ namespace Piranha.EF
         /// Initializes the module.
         /// </summary>
         public void Init() {
-            var config = new MapperConfiguration(cfg => {
-                cfg.CreateMap<Data.Category, Models.CategoryItem>();
-                cfg.CreateMap<Data.Category, Models.Category>();
+            if (!isInitialized) {
+                lock(mutex) {
+                    if (!isInitialized) {
+                        var config = new MapperConfiguration(cfg => {
+                            cfg.CreateMap<Data.Category, Models.CategoryItem>();
+                            cfg.CreateMap<Data.Category, Models.Category>();
 
-                cfg.CreateMap<Models.CategoryItem, Data.Category>()
-                    .ForMember(m => m.Id, o => o.Ignore())
-                    .ForMember(m => m.EnableArchive, o => o.Ignore())
-                    .ForMember(m => m.ArchiveTitle, o => o.Ignore())
-                    .ForMember(m => m.ArchiveKeywords, o => o.Ignore())
-                    .ForMember(m => m.ArchiveDescription, o => o.Ignore())
-                    .ForMember(m => m.ArchiveRoute, o => o.Ignore())
-                    .ForMember(m => m.Created, o => o.Ignore())
-                    .ForMember(m => m.LastModified, o => o.Ignore());
-                cfg.CreateMap<Models.Category, Data.Category>()
-                    .ForMember(m => m.Id, o => o.Ignore())
-                    .ForMember(m => m.Created, o => o.Ignore())
-                    .ForMember(m => m.LastModified, o => o.Ignore());
+                            cfg.CreateMap<Models.CategoryItem, Data.Category>()
+                                .ForMember(m => m.Id, o => o.Ignore())
+                                .ForMember(m => m.EnableArchive, o => o.Ignore())
+                                .ForMember(m => m.ArchiveTitle, o => o.Ignore())
+                                .ForMember(m => m.ArchiveKeywords, o => o.Ignore())
+                                .ForMember(m => m.ArchiveDescription, o => o.Ignore())
+                                .ForMember(m => m.ArchiveRoute, o => o.Ignore())
+                                .ForMember(m => m.Created, o => o.Ignore())
+                                .ForMember(m => m.LastModified, o => o.Ignore());
+                            cfg.CreateMap<Models.Category, Data.Category>()
+                                .ForMember(m => m.Id, o => o.Ignore())
+                                .ForMember(m => m.Created, o => o.Ignore())
+                                .ForMember(m => m.LastModified, o => o.Ignore());
 
-                cfg.CreateMap<Data.Media, Models.MediaItem>();
-                cfg.CreateMap<Data.Media, Models.Media>();
+                            cfg.CreateMap<Data.Media, Models.MediaItem>();
+                            cfg.CreateMap<Data.Media, Models.Media>();
 
-                cfg.CreateMap<Data.Page, Models.PageBase>();
-                cfg.CreateMap<Models.PageBase, Data.Page>()
-                    .ForMember(m => m.Id, o => o.Ignore())
-                    .ForMember(m => m.Created, o => o.Ignore())
-                    .ForMember(m => m.LastModified, o => o.Ignore())
-                    .ForMember(m => m.Type, o => o.Ignore())
-                    .ForMember(m => m.Fields, o => o.Ignore());
+                            cfg.CreateMap<Data.Page, Models.PageBase>();
+                            cfg.CreateMap<Models.PageBase, Data.Page>()
+                                .ForMember(m => m.Id, o => o.Ignore())
+                                .ForMember(m => m.Created, o => o.Ignore())
+                                .ForMember(m => m.LastModified, o => o.Ignore())
+                                .ForMember(m => m.Type, o => o.Ignore())
+                                .ForMember(m => m.Fields, o => o.Ignore());
 
-                cfg.CreateMap<Data.Post, Models.Post>()
-                    .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
-                    .ForMember(m => m.Category, o => o.Ignore())
-                    .ForMember(m => m.Tags, o => o.Ignore());
-                cfg.CreateMap<Data.Post, Models.PostItem>()
-                    .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
-                    .ForMember(m => m.Category, o => o.Ignore())
-                    .ForMember(m => m.Tags, o => o.Ignore());
-            });
+                            cfg.CreateMap<Data.Post, Models.Post>()
+                                .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
+                                .ForMember(m => m.Category, o => o.Ignore())
+                                .ForMember(m => m.Tags, o => o.Ignore());
+                            cfg.CreateMap<Data.Post, Models.PostItem>()
+                                .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
+                                .ForMember(m => m.Category, o => o.Ignore())
+                                .ForMember(m => m.Tags, o => o.Ignore());
+                        });
 
-            config.AssertConfigurationIsValid();
-            Mapper = config.CreateMapper();
+                        config.AssertConfigurationIsValid();
+                        Mapper = config.CreateMapper();
 
-            Serializer = new Serializers.SerializerManager();
-            Serializer.Register<Extend.Fields.HtmlField>(new Serializers.StringSerializer<Extend.Fields.HtmlField>());
-            Serializer.Register<Extend.Fields.MarkdownField>(new Serializers.StringSerializer<Extend.Fields.MarkdownField>());
-            Serializer.Register<Extend.Fields.StringField>(new Serializers.StringSerializer<Extend.Fields.StringField>());
-            Serializer.Register<Extend.Fields.TextField>(new Serializers.StringSerializer<Extend.Fields.TextField>());
+                        Serializer = new Serializers.SerializerManager();
+                        Serializer.Register<Extend.Fields.HtmlField>(new Serializers.StringSerializer<Extend.Fields.HtmlField>());
+                        Serializer.Register<Extend.Fields.MarkdownField>(new Serializers.StringSerializer<Extend.Fields.MarkdownField>());
+                        Serializer.Register<Extend.Fields.StringField>(new Serializers.StringSerializer<Extend.Fields.StringField>());
+                        Serializer.Register<Extend.Fields.TextField>(new Serializers.StringSerializer<Extend.Fields.TextField>());
 
+                        isInitialized = true;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/data/Piranha.EF/Module.cs
+++ b/src/data/Piranha.EF/Module.cs
@@ -19,9 +19,6 @@ namespace Piranha.EF
     /// </summary>
     public class Module : Extend.IModule
     {
-        private static bool isInitialized = false;
-        private static readonly object mutex = new object();
-
         /// <summary>
         /// Gets the mapper.
         /// </summary>
@@ -41,61 +38,53 @@ namespace Piranha.EF
         /// Initializes the module.
         /// </summary>
         public void Init() {
-            if (!isInitialized) {
-                lock(mutex) {
-                    if (!isInitialized) {
-                        var config = new MapperConfiguration(cfg => {
-                            cfg.CreateMap<Data.Category, Models.CategoryItem>();
-                            cfg.CreateMap<Data.Category, Models.Category>();
+            var config = new MapperConfiguration(cfg => {
+                cfg.CreateMap<Data.Category, Models.CategoryItem>();
+                cfg.CreateMap<Data.Category, Models.Category>();
 
-                            cfg.CreateMap<Models.CategoryItem, Data.Category>()
-                                .ForMember(m => m.Id, o => o.Ignore())
-                                .ForMember(m => m.EnableArchive, o => o.Ignore())
-                                .ForMember(m => m.ArchiveTitle, o => o.Ignore())
-                                .ForMember(m => m.ArchiveKeywords, o => o.Ignore())
-                                .ForMember(m => m.ArchiveDescription, o => o.Ignore())
-                                .ForMember(m => m.ArchiveRoute, o => o.Ignore())
-                                .ForMember(m => m.Created, o => o.Ignore())
-                                .ForMember(m => m.LastModified, o => o.Ignore());
-                            cfg.CreateMap<Models.Category, Data.Category>()
-                                .ForMember(m => m.Id, o => o.Ignore())
-                                .ForMember(m => m.Created, o => o.Ignore())
-                                .ForMember(m => m.LastModified, o => o.Ignore());
+                cfg.CreateMap<Models.CategoryItem, Data.Category>()
+                    .ForMember(m => m.Id, o => o.Ignore())
+                    .ForMember(m => m.EnableArchive, o => o.Ignore())
+                    .ForMember(m => m.ArchiveTitle, o => o.Ignore())
+                    .ForMember(m => m.ArchiveKeywords, o => o.Ignore())
+                    .ForMember(m => m.ArchiveDescription, o => o.Ignore())
+                    .ForMember(m => m.ArchiveRoute, o => o.Ignore())
+                    .ForMember(m => m.Created, o => o.Ignore())
+                    .ForMember(m => m.LastModified, o => o.Ignore());
+                cfg.CreateMap<Models.Category, Data.Category>()
+                    .ForMember(m => m.Id, o => o.Ignore())
+                    .ForMember(m => m.Created, o => o.Ignore())
+                    .ForMember(m => m.LastModified, o => o.Ignore());
 
-                            cfg.CreateMap<Data.Media, Models.MediaItem>();
-                            cfg.CreateMap<Data.Media, Models.Media>();
+                cfg.CreateMap<Data.Media, Models.MediaItem>();
+                cfg.CreateMap<Data.Media, Models.Media>();
 
-                            cfg.CreateMap<Data.Page, Models.PageBase>();
-                            cfg.CreateMap<Models.PageBase, Data.Page>()
-                                .ForMember(m => m.Id, o => o.Ignore())
-                                .ForMember(m => m.Created, o => o.Ignore())
-                                .ForMember(m => m.LastModified, o => o.Ignore())
-                                .ForMember(m => m.Type, o => o.Ignore())
-                                .ForMember(m => m.Fields, o => o.Ignore());
+                cfg.CreateMap<Data.Page, Models.PageBase>();
+                cfg.CreateMap<Models.PageBase, Data.Page>()
+                    .ForMember(m => m.Id, o => o.Ignore())
+                    .ForMember(m => m.Created, o => o.Ignore())
+                    .ForMember(m => m.LastModified, o => o.Ignore())
+                    .ForMember(m => m.Type, o => o.Ignore())
+                    .ForMember(m => m.Fields, o => o.Ignore());
 
-                            cfg.CreateMap<Data.Post, Models.Post>()
-                                .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
-                                .ForMember(m => m.Category, o => o.Ignore())
-                                .ForMember(m => m.Tags, o => o.Ignore());
-                            cfg.CreateMap<Data.Post, Models.PostItem>()
-                                .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
-                                .ForMember(m => m.Category, o => o.Ignore())
-                                .ForMember(m => m.Tags, o => o.Ignore());
-                        });
+                cfg.CreateMap<Data.Post, Models.Post>()
+                    .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
+                    .ForMember(m => m.Category, o => o.Ignore())
+                    .ForMember(m => m.Tags, o => o.Ignore());
+                cfg.CreateMap<Data.Post, Models.PostItem>()
+                    .ForMember(m => m.Permalink, o => o.MapFrom(p => p.Category.Slug + "/" + p.Slug))
+                    .ForMember(m => m.Category, o => o.Ignore())
+                    .ForMember(m => m.Tags, o => o.Ignore());
+            });
 
-                        config.AssertConfigurationIsValid();
-                        Mapper = config.CreateMapper();
+            config.AssertConfigurationIsValid();
+            Mapper = config.CreateMapper();
 
-                        Serializer = new Serializers.SerializerManager();
-                        Serializer.Register<Extend.Fields.HtmlField>(new Serializers.StringSerializer<Extend.Fields.HtmlField>());
-                        Serializer.Register<Extend.Fields.MarkdownField>(new Serializers.StringSerializer<Extend.Fields.MarkdownField>());
-                        Serializer.Register<Extend.Fields.StringField>(new Serializers.StringSerializer<Extend.Fields.StringField>());
-                        Serializer.Register<Extend.Fields.TextField>(new Serializers.StringSerializer<Extend.Fields.TextField>());
-
-                        isInitialized = true;
-                    }
-                }
-            }
+            Serializer = new Serializers.SerializerManager();
+            Serializer.Register<Extend.Fields.HtmlField>(new Serializers.StringSerializer<Extend.Fields.HtmlField>());
+            Serializer.Register<Extend.Fields.MarkdownField>(new Serializers.StringSerializer<Extend.Fields.MarkdownField>());
+            Serializer.Register<Extend.Fields.StringField>(new Serializers.StringSerializer<Extend.Fields.StringField>());
+            Serializer.Register<Extend.Fields.TextField>(new Serializers.StringSerializer<Extend.Fields.TextField>());
         }
     }
 }

--- a/src/examples/Blog/Startup.cs
+++ b/src/examples/Blog/Startup.cs
@@ -94,7 +94,7 @@ namespace Blog
                 // Add the startpage
                 using (var stream = File.OpenRead("assets/seed/startpage.md")) {
                     using (var reader = new StreamReader(stream)) {
-                        var startPage = Models.ContentPageModel.Create("Content");
+                        var startPage = Models.ContentPageModel.Create(api, "Content");
                         startPage.Title = "Welcome to Piranha CMS";
                         startPage.Ingress = "The CMS framework with an extra bite";
                         startPage.Body = reader.ReadToEnd();

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/ManagerAreaControllerUnitTestBase.cs
@@ -29,7 +29,10 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         /// </summary>
         protected virtual IModule[] Modules {
             get {
-                return null;
+                return new IModule[] {
+                    new Piranha.EF.Module(),
+                    new Piranha.Manager.Module()
+                };
             }
         }
 

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
@@ -211,7 +211,8 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Edit_WithInvalidPageIdGivesThrowsKeyNotFoundException(int pageIdAsInt) {
             #region Arrange
             Guid invalidPageId = ConvertIntToGuid(pageIdAsInt);
-            bool exceptionCaught = false;
+            bool expectedExceptionTypeCaught = false;
+            Type caughtExceptionType = null;
             #endregion
 
             #region Act
@@ -219,12 +220,15 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
                 ViewResult result = controller.Edit(invalidPageId) as ViewResult;
             } catch (KeyNotFoundException e) {
                 Assert.Equal($"No page found with the id '{invalidPageId}'", e.Message);
-                exceptionCaught = true;
+                expectedExceptionTypeCaught = true;
+            } catch (Exception e) {
+                expectedExceptionTypeCaught = false;
+                caughtExceptionType = e.GetType();
             }
             #endregion
 
             #region Assert
-            Assert.True(exceptionCaught);
+            Assert.True(expectedExceptionTypeCaught, string.Format("Incorrect exception type caught: {0}", caughtExceptionType));
             #endregion
         }
 
@@ -300,20 +304,24 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Add_WithInvalidPageTypeIdThrowsKeyNotFoundException(int pageTypeIdAsInt) {
             #region Arrange
             string pageTypeId = ConvertIntToGuid(pageTypeIdAsInt).ToString();
-            bool exceptionCaught = false;
+            bool expectedExceptionTypeCaught = false;
+            Type caughtExceptionType = null;
             #endregion
 
             #region Act
             try {
                 ViewResult result = controller.Add(pageTypeId) as ViewResult;
             } catch (KeyNotFoundException e) {
-                exceptionCaught = true;
+                expectedExceptionTypeCaught = true;
                 Assert.Equal($"No page type found with the id '{pageTypeId}'", e.Message);
+            } catch (Exception e) {
+                expectedExceptionTypeCaught = false;
+                caughtExceptionType = e.GetType();
             }
             #endregion
 
             #region Assert
-            Assert.True(exceptionCaught);
+            Assert.True(expectedExceptionTypeCaught, string.Format("Incorrect exception type caught: {0}", caughtExceptionType));
             #endregion
         }
 
@@ -370,21 +378,25 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Save_NewPageWithInvalidPageTypeIdThrowsKeyNotFoundException(int pageTypeIdAsInt) {
             #region Arrange
             Guid pageTypeId = ConvertIntToGuid(pageTypeIdAsInt);
-            PageEditModel pageToSave = PageEditModelForPageType(pageTypeId);
-            bool exceptionCaught = false;
+            PageEditModel pageToSave = PageEditModelForPageType(NUM_PAGES + 1, pageTypeId);
+            bool expectedExceptionTypeCaught = false;
+            Type caughtExceptionType = null;
             #endregion
 
             #region Act
             try {
                 IActionResult result = controller.Save(pageToSave);
             } catch (KeyNotFoundException e) {
-                exceptionCaught = true;
-                Assert.Equal($"No page type found with id '{pageTypeId}'", e.Message);
+                expectedExceptionTypeCaught = true;
+                Assert.Equal($"No page found with id '{pageToSave.Id}', and no page type found found with id '{pageTypeId}'", e.Message);
+            } catch (Exception e) {
+                expectedExceptionTypeCaught = false;
+                caughtExceptionType = e.GetType();
             }
             #endregion
 
             #region Assert
-            Assert.True(exceptionCaught);
+            Assert.True(expectedExceptionTypeCaught, string.Format("Incorrect exception type caught: {0}", caughtExceptionType));
             #endregion
         }
 
@@ -396,7 +408,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Save_NewPageIsSuccessfulAndRedirectsToList() {
             #region Arrange
             int pageTypeIdAsInt = 1;
-            PageEditModel pageToSave = PageEditModelForPageType(ConvertIntToGuid(pageTypeIdAsInt));
+            PageEditModel pageToSave = PageEditModelForPageType(NUM_PAGES + 1, ConvertIntToGuid(pageTypeIdAsInt));
             #endregion
 
             #region Act
@@ -434,9 +446,8 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             string pageTitleUpdate = $"Updated title {pageIdAsInt}";
             DynamicPage page = pages.FirstOrDefault(p => p.Id == pageId);
 
-            PageEditModel pageToSave = PageEditModelForPageType(new Guid(page.TypeId));
+            PageEditModel pageToSave = PageEditModelForPageType(pageIdAsInt, new Guid(page.TypeId));
             DateTime? expectedPublishTime = pageToSave.Published;
-            pageToSave.Id = pageId;
             pageToSave.Title = pageTitleUpdate;
             pageToSave.Published = expectedPublishTime;
             #endregion
@@ -462,7 +473,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Save_NewPageWithFailedSaveReturnsView() {
             #region Arrange
             int pageTypeIdAsInt = 1;
-            PageEditModel pageToSave = PageEditModelForPageType(ConvertIntToGuid(pageTypeIdAsInt));
+            PageEditModel pageToSave = PageEditModelForPageType(NUM_PAGES + 1, ConvertIntToGuid(pageTypeIdAsInt));
             mockApi.Setup(a => a.Pages.Save(It.Is<DynamicPage>(p => p.Id == pageToSave.Id))).Throws(new Exception("DbUpdateConcurrencyException"));
             #endregion
 
@@ -495,21 +506,25 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Publish_NewPageWithInvalidPageTypeIdThrowsKeyNotFoundException(int pageTypeIdAsInt) {
             #region Arrange
             Guid pageTypeId = ConvertIntToGuid(pageTypeIdAsInt);
-            PageEditModel pageToPublish = PageEditModelForPageType(pageTypeId);
-            bool exceptionCaught = false;
+            PageEditModel pageToPublish = PageEditModelForPageType(NUM_PAGES + 1, pageTypeId);
+            bool expectedExceptionTypeCaught = false;
+            Type caughtExceptionType = null;
             #endregion
 
             #region Act
             try {
                 IActionResult result = controller.Publish(pageToPublish);
             } catch (KeyNotFoundException e) {
-                exceptionCaught = true;
-                Assert.Equal($"No page type found with id '{pageTypeId}'", e.Message);
+                expectedExceptionTypeCaught = true;
+                Assert.Equal($"No page found with id '{pageToPublish.Id}', and no page type found found with id '{pageTypeId}'", e.Message);
+            } catch (Exception e) {
+                expectedExceptionTypeCaught = false;
+                caughtExceptionType = e.GetType();
             }
             #endregion
 
             #region Assert
-            Assert.True(exceptionCaught);
+            Assert.True(expectedExceptionTypeCaught, string.Format("Incorrect exception type caught: {0}", caughtExceptionType));
             #endregion
         }
 
@@ -521,7 +536,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Publish_NewPageIsSuccessfulAndRedirectsToList() {
             #region Arrange
             int pageTypeIdAsInt = 1;
-            PageEditModel pageToPublish = PageEditModelForPageType(ConvertIntToGuid(pageTypeIdAsInt));
+            PageEditModel pageToPublish = PageEditModelForPageType(NUM_PAGES + 1, ConvertIntToGuid(pageTypeIdAsInt));
             #endregion
 
             #region Act
@@ -559,9 +574,8 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             string pageTitleUpdate = $"Updated title {pageIdAsInt}";
             DynamicPage page = pages.FirstOrDefault(p => p.Id == pageId);
 
-            PageEditModel pageToPublish = PageEditModelForPageType(new Guid(page.TypeId));
+            PageEditModel pageToPublish = PageEditModelForPageType(pageIdAsInt, new Guid(page.TypeId));
             DateTime? originalPublishTime = pageToPublish.Published;
-            pageToPublish.Id = pageId;
             pageToPublish.Title = pageTitleUpdate;
             pageToPublish.Published = originalPublishTime;
             #endregion
@@ -587,7 +601,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void Publish_NewPageWithFailedPublishReturnsView() {
             #region Arrange
             int pageTypeIdAsInt = 1;
-            PageEditModel pageToPublish = PageEditModelForPageType(ConvertIntToGuid(pageTypeIdAsInt));
+            PageEditModel pageToPublish = PageEditModelForPageType(NUM_PAGES + 1, ConvertIntToGuid(pageTypeIdAsInt));
             mockApi.Setup(a => a.Pages.Save(It.Is<DynamicPage>(p => p.Id == pageToPublish.Id))).Throws(new Exception("DbUpdateConcurrencyException"));
             #endregion
 
@@ -620,21 +634,25 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void UnPublish_NewPageWithInvalidPageTypeIdThrowsKeyNotFoundException(int pageTypeIdAsInt) {
             #region Arrange
             Guid pageTypeId = ConvertIntToGuid(pageTypeIdAsInt);
-            PageEditModel pageToPublish = PageEditModelForPageType(pageTypeId);
-            bool exceptionCaught = false;
+            PageEditModel pageToPublish = PageEditModelForPageType(NUM_PAGES + 1, pageTypeId);
+            bool expectedExceptionTypeCaught = false;
+            Type caughtExceptionType = null;
             #endregion
 
             #region Act
             try {
                 IActionResult result = controller.UnPublish(pageToPublish);
             } catch (KeyNotFoundException e) {
-                exceptionCaught = true;
-                Assert.Equal($"No page type found with id '{pageTypeId}'", e.Message);
+                expectedExceptionTypeCaught = true;
+                Assert.Equal($"No page found with id '{pageToPublish.Id}', and no page type found found with id '{pageTypeId}'", e.Message);
+            } catch (Exception e) {
+                expectedExceptionTypeCaught = false;
+                caughtExceptionType = e.GetType();
             }
             #endregion
 
             #region Assert
-            Assert.True(exceptionCaught);
+            Assert.True(expectedExceptionTypeCaught, string.Format("Incorrect exception type caught: {0}", caughtExceptionType));
             #endregion
         }
 
@@ -646,7 +664,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void UnPublish_NewPageIsSuccessfulAndRedirectsToList() {
             #region Arrange
             int pageTypeIdAsInt = 1;
-            PageEditModel pageToPublish = PageEditModelForPageType(ConvertIntToGuid(pageTypeIdAsInt));
+            PageEditModel pageToPublish = PageEditModelForPageType(NUM_PAGES + 1, ConvertIntToGuid(pageTypeIdAsInt));
             #endregion
 
             #region Act
@@ -684,9 +702,8 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             string pageTitleUpdate = $"Updated title {pageIdAsInt}";
             DynamicPage page = pages.FirstOrDefault(p => p.Id == pageId);
 
-            PageEditModel pageToPublish = PageEditModelForPageType(new Guid(page.TypeId));
+            PageEditModel pageToPublish = PageEditModelForPageType(pageIdAsInt, new Guid(page.TypeId));
             DateTime? originalPublishTime = pageToPublish.Published;
-            pageToPublish.Id = pageId;
             pageToPublish.Title = pageTitleUpdate;
             pageToPublish.Published = originalPublishTime;
             #endregion
@@ -712,7 +729,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         public void UnPublish_NewPageWithFailedPublishReturnsView() {
             #region Arrange
             int pageTypeIdAsInt = 1;
-            PageEditModel pageToPublish = PageEditModelForPageType(ConvertIntToGuid(pageTypeIdAsInt));
+            PageEditModel pageToPublish = PageEditModelForPageType(NUM_PAGES + 1, ConvertIntToGuid(pageTypeIdAsInt));
             mockApi.Setup(a => a.Pages.Save(It.Is<DynamicPage>(p => p.Id == pageToPublish.Id))).Throws(new Exception("DbUpdateConcurrencyException"));
             #endregion
 
@@ -778,9 +795,9 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         /// <returns>
         /// The new page model
         /// </returns>
-        private PageEditModel PageEditModelForPageType(Guid pageTypeId) {
+        private PageEditModel PageEditModelForPageType(int pageIdAsInt, Guid pageTypeId) {
             return new PageEditModel {
-                Id = ConvertIntToGuid(NUM_PAGES + 1),
+                Id = ConvertIntToGuid(pageIdAsInt),
                 TypeId = pageTypeId.ToString(),
                 PageType = pageTypes.FirstOrDefault(t => t.Id == pageTypeId.ToString())
             };

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
@@ -124,6 +124,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             for (int i = 1; i <= NUM_PAGES; i++) {
                 int pageTypeId = (i % NUM_PAGE_TYPES) + 1;
                 DynamicPage pageToAdd = Models.Page<DynamicPage>.Create(
+                    mockApi.Object,
                     ConvertIntToGuid(pageTypeId).ToString()
                 );
                 pageToAdd.Id = ConvertIntToGuid(i);

--- a/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
+++ b/test/core/Piranha.Manager.Tests/Areas/Manager/Controllers/PageControllerUnitTest.cs
@@ -29,16 +29,6 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
     public class PageControllerUnitTest : ManagerAreaControllerUnitTestBase<PageController>
     {
         #region Properties
-        #region Protected Properties
-        protected override IModule[] Modules {
-            get {
-                return new IModule[] {
-                    new Piranha.Manager.Module()
-                };
-            }
-        }
-        #endregion
-
         #region Private Properties
         /// <summary>
         /// The number of sample page types to insert
@@ -67,7 +57,7 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
             var api = new Mock<IApi>();
 
             api.Setup(a => a.BlockTypes.Get()).Returns(new List<Extend.BlockType>());
-            SetupPageTypeReporitoryMethods(api);
+            SetupPageTypeRepository(api);
 
             return api;
         }
@@ -75,9 +65,12 @@ namespace Piranha.Manager.Tests.Areas.Manager.Controllers
         /// Initializes <see cref="pageTypes" /> and sets <see cref="IApi.PageTypes.Get" />
         /// return value
         /// </summary>
-        private void SetupPageTypeReporitoryMethods(Mock<IApi> api) {
+        private void SetupPageTypeRepository(Mock<IApi> api) {
             InitializePageTypes();
             api.Setup(a => a.PageTypes.Get()).Returns(pageTypes);
+            api.Setup(a => a.PageTypes.GetById(It.IsAny<string>())).Returns(
+                (Func<string, PageType>)(pageTypeId => pageTypes.FirstOrDefault(t => t.Id == pageTypeId))
+            );
         }
         /// <summary>
         /// Initializes <see cref="pageTypes" /> with <see cref="NUM_PAGE_TYPES" />

--- a/test/data/Piranha.EF.Tests/Repositories/CategoryRepositoryUnitTest.cs
+++ b/test/data/Piranha.EF.Tests/Repositories/CategoryRepositoryUnitTest.cs
@@ -17,10 +17,8 @@ using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
-namespace Piranha.EF.Tests.Repositories
-{
-    public class CategoryRepositoryUnitTest : RepositoryUnitTestBase<CategoryRepository>
-    {
+namespace Piranha.EF.Tests.Repositories {
+    public class CategoryRepositoryUnitTest : RepositoryUnitTestBase<CategoryRepository> {
         #region Properties
         /// <summary>
         /// Numver of categories to create for testing
@@ -47,6 +45,7 @@ namespace Piranha.EF.Tests.Repositories
         protected override void SetupMockDbData() {
             CreateCategories();
             SetupMockDbSet(mockCategoryDbSet, Categories);
+            mockDb.Setup(db => db.Set<Data.Category>()).Returns(mockCategoryDbSet.Object);
         }
         private void CreateCategories() {
             for (int i = 1; i <= NUM_CATEGORIES; i++) {
@@ -60,7 +59,7 @@ namespace Piranha.EF.Tests.Repositories
                 };
                 categoriesList.Add(newCategory);
             }
-           
+
         }
 
         protected override CategoryRepository SetupRepository() {
@@ -81,11 +80,11 @@ namespace Piranha.EF.Tests.Repositories
             string slug = $"Slug{slugNumber}";
             Models.CategoryItem expectedCategory = categoriesList.FirstOrDefault(c => c.Slug == slug);
             #endregion
-        
+
             #region Act
             Models.CategoryItem result = repository.GetBySlug(slug);
             #endregion
-        
+
             #region Assert
             Assert_CategoryItemsMatch(expectedCategory, result);
             #endregion
@@ -98,11 +97,11 @@ namespace Piranha.EF.Tests.Repositories
             #region Arrange
             string slug = $"Slug{slugNumber}";
             #endregion
-        
+
             #region Act
             Models.CategoryItem result = repository.GetBySlug(slug);
             #endregion
-        
+
             #region Assert
             Assert_CategoryItemsMatch(null, result);
             #endregion
@@ -119,16 +118,21 @@ namespace Piranha.EF.Tests.Repositories
         public void GetModelById_ValidIdReturnsCorrectCategory(int idAsInt) {
             #region Arrange
             Guid categoryId = ConvertIntToGuid(idAsInt);
-            Models.Category expectedCategory = null;
-            // TODO: Set expected category
+            Data.Category expectedCategory = categoriesList.FirstOrDefault(c => c.Id == categoryId);
+            Models.Category expectedModelCategory = new Models.Category {
+                Id = expectedCategory.Id,
+                Title = expectedCategory.Title,
+                Description = expectedCategory.Description,
+                Slug = expectedCategory.Slug
+            };
             #endregion
-        
+
             #region Act
             Models.Category result = repository.GetModelById(categoryId);
             #endregion
-        
+
             #region Assert
-            Assert_CategoryMatches(expectedCategory, result);
+            Assert_CategoriesMatch(expectedModelCategory, result);
             #endregion
         }
 
@@ -139,13 +143,130 @@ namespace Piranha.EF.Tests.Repositories
             #region Arrange
             Guid categoryId = ConvertIntToGuid(idAsInt);
             #endregion
-        
+
             #region Act
             Models.Category result = repository.GetModelById(categoryId);
             #endregion
-        
+
             #region Assert
-            Assert_CategoryMatches(null, result);
+            Assert_CategoriesMatch(null, result);
+            #endregion
+        }
+        #endregion
+
+        #region CategoryRepository.GetModelBySlug
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        public void GetModelBySlug_ValidSlugReturnsCorrectModel(int slugNumber) {
+            #region Arrange
+            string slug = $"Slug{slugNumber}";
+            Data.Category expectedCategory = categoriesList.FirstOrDefault(c => c.Slug == slug);
+            Models.Category expectedModelCategory = new Models.Category {
+                Id = expectedCategory.Id,
+                Title = expectedCategory.Title,
+                Slug = expectedCategory.Slug,
+                Description = expectedCategory.Description
+            };
+            #endregion
+
+            #region Act
+            Models.Category result = repository.GetModelBySlug(slug);
+            #endregion
+
+            #region Assert
+            Assert_CategoriesMatch(expectedModelCategory, result);
+            #endregion
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(NUM_CATEGORIES + 1)]
+        public void GetModelBySlug_InvalidSlugReturnsNull(int slugNumber) {
+            #region Arrange
+            string slug = $"Slug{slugNumber}";
+            #endregion
+
+            #region Act
+            Models.Category result = repository.GetModelBySlug(slug);
+            #endregion
+
+            #region Assert
+            Assert_CategoriesMatch(null, result);
+            #endregion
+        }
+        #endregion
+
+        #region CategoryRepository.Get
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        public void Get_ReturnsCorrectListOrderedByTitle(int numItemsToRemove) {
+            #region Arrange
+            Shuffle(categoriesList);
+            categoriesList.RemoveRange(0, numItemsToRemove);
+
+            List<Models.CategoryItem> expectedList = new List<Models.CategoryItem>();
+            foreach (var category in categoriesList.OrderBy(c => c.Title)) {
+                expectedList.Add(new Models.Category {
+                    Id = category.Id,
+                    Title = category.Title,
+                    Slug = category.Slug,
+                    Description = category.Description
+                });
+            }
+            #endregion
+
+            #region Act
+            IList<Models.CategoryItem> result = repository.Get();
+            #endregion
+
+            #region Assert
+            Assert.Equal(expectedList.Count, result.Count);
+            for (int i = 0; i < expectedList.Count; i++) {
+                Assert_CategoryItemsMatch(expectedList[i], result[i]);
+            }
+            #endregion
+        }
+        #endregion
+
+        #region CategoryRepository.GetModels
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        public void GetModels_ReturnsCorrectListOrderedByTitle(int numItemsToRemove) {
+            #region Arrange
+            Shuffle(categoriesList);
+            categoriesList.RemoveRange(0, numItemsToRemove);
+
+            List<Models.Category> expectedList = new List<Models.Category>();
+            foreach (var category in categoriesList.OrderBy(c => c.Title)) {
+                expectedList.Add(new Models.Category {
+                    Id = category.Id,
+                    Title = category.Title,
+                    Slug = category.Slug,
+                    Description = category.Description
+                });
+            }
+            #endregion
+
+            #region Act
+            IList<Models.Category> result = repository.GetModels();
+            #endregion
+
+            #region Assert
+            Assert.Equal(expectedList.Count, result.Count);
             #endregion
         }
         #endregion
@@ -162,7 +283,7 @@ namespace Piranha.EF.Tests.Repositories
                 Assert.Equal(expected.Id, actual.Id);
             }
         }
-        private void Assert_CategoryMatches(Models.Category expected, Models.Category actual) {
+        private void Assert_CategoriesMatch(Models.Category expected, Models.Category actual) {
             if (expected == null) {
                 Assert.Null(actual);
             } else {

--- a/test/data/Piranha.EF.Tests/Repositories/RepositoryUnitTestBase.cs
+++ b/test/data/Piranha.EF.Tests/Repositories/RepositoryUnitTestBase.cs
@@ -12,6 +12,8 @@ using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Moq;
+using AutoMapper;
+using System.Collections.Generic;
 
 namespace Piranha.EF.Tests.Repositories
  {
@@ -37,6 +39,8 @@ namespace Piranha.EF.Tests.Repositories
         public RepositoryUnitTestBase() {
             mockDb = new Mock<IDb>();
             repository = SetupRepository();
+            Module module = new Module();
+            module.Init();
             SetupMockDbData();
         }
 
@@ -78,6 +82,27 @@ namespace Piranha.EF.Tests.Repositories
             mockDbSet.As<IQueryable<T>>().Setup(s => s.Expression).Returns(source.Expression);
             mockDbSet.As<IQueryable<T>>().Setup(s => s.ElementType).Returns(source.ElementType);
             mockDbSet.As<IQueryable<T>>().Setup(s => s.GetEnumerator()).Returns(source.GetEnumerator());
+        }
+
+        /// <summary>
+        /// Randomizes the ordering of the given list in place
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="listToShuffle">The list to shuffle</param>
+        /// <remarks>
+        /// Solution found StackOverflow http://stackoverflow.com/a/1262619/5884242
+        /// </remarks>
+        protected void Shuffle<T>(IList<T> listToShuffle) {
+            Random rng = new Random();
+            int n = listToShuffle.Count;
+
+            while (n > 1) {
+                n--;
+                int k = rng.Next(n + 1);
+                T value = listToShuffle[k];
+                listToShuffle[k] = listToShuffle[n];
+                listToShuffle[n] = value;
+            }
         }
     }
  }


### PR DESCRIPTION
## Repairing non-deterministic test results
I was able to fix several instances of non-deterministic results by modifying the following methods to use an injected `IApi` instance instead of `App.PageTypes` (seen in commit 05cee5f87613080bb6ca1567a1fe553ad77ab8b7)
* `Piranha.Models.Page.Create<T>()`
* `Piranha.Models.PageEditModel.Create()`
    * Caused `PageController.Add()` to be changed as well

With this change, it removed the non-deterministic issues of modifying PageTypes containers in the `PageControllerUnitTest` class but obviously removes more of the `App.PageTypes` caching. However, this has given me a new idea for how `App.PageTypes` was supposed to serve as a cache; what if the `IApi` interface had a "PageTypes" get-only property that operates as the cache? Here's an example implementation of what I'm thinking:
```
// Refresh every ten minutes
private readonly TimeSpan pageTypeRefreshInterval = new TimeSpan(0, 10, 0);
private DateTime pageTypesExpireAt;
private IList<PageType> cachedPageTypes;

public IList<PageType> CachedPageTypes {
    get {
        if (DateTime.Now > pageTypesExpireAt) {
            cachedPageTypes = PageTypes.Get();
            pageTypesExpireAt = DateTime.Now.Add(pageTypeRefreshInterval)
        }
        return cachedPageTypes;
    }
}
```
This idea would still allow for a cached PageType set, while also allowing for DI in unit tests. This would also need some kind of "UpdateCache" method similar to `App.ReloadPageTypes()`, handling when PageTypes are added/deleted. However, this suggestion only improves caching for a single request, since the `IApi` service is a scoped instance, as opposed to the entire lifetime of the application.


## Failing unit tests:
As discussed in #42 I've created a more itemized list of tests that are failing because they are currently "designed to fail", as in they don't match patterns established in other situations but I think they should (for consistency sake). Below are the unit tests, a description of why they are failing, and a possible solution to them.

### PageControllerUnitTest.Save_NewPageWithInvalidPageTypeThrowsKetNotFoundException()
* The idea behind this test is, if someone is tampering with hidden form values like the PageTypeId of a new page being Saved, we shouldn't be getting a `NullReferenceException` by accessing the page in the `PageEditModel.Save()` method (since we can neither retrieve nor create the page)
* I suggest the following code change to `PageEditModel.Save()`:
```
var page = (api.Pages.GetById(id) ?? Pianha.Models.DynamicPage.Create(api, this.TypeId));
if (page == null) {
    throw new KeyNotFoundException($"No page found with id '{Id}', and no page type found found with id '{TypeId}'");
}
```

### PageControllerUnitTest.Publish_NewPageWithInvalidPageTypeThrowsKeyNotFoundException()
Same as Save_NewPageWithInvalidPageTypeThrowsKeyNotFoundException

### PageControllerUnitTest.UnPublish_NewPageWithInvalidPageTypeThrowsKeyNotFoundException()
Same as Save_NewPageWithInvalidPageTypeThrowsKeyNotFoundExcepion

### PageControllerUnitTest.Save_NewPageWithFailedSaveReturnsView
* The idea behind this test is, what should happen when `IApi.Pages.Save()` throws some kind of exception, such as a DbConcurrencyUpdateException? The code in the controller method returns the View if the `PageEditModel.Save()` method returns false. The only case, at this point, I think the method should return false if `IApi.Pages.Save()` throws an exception/fails.
* Suggested fix is as follows:
```
try {
    api.Pages.Save(page);
} catch {
    return false;
}
```
### PageControllerUnitTest.Publish_NewPageWithFailedSaveReturnsView
Same as Save_NewPageWithFailedSaveReturnsView

### PageControllerUnitTest.UnPublish_NewPageWithFailedSaveReturnsView
Same as Save_NewPageWithFailedSaveReturnsView

## Fixing failing tests
I do have the code fixes suggested above for the failing tests already written, I just didn't commit them because I wasn't sure if those suggestions would be implemented or if something else entirely would be used. If you want those changes let me know before the PR is merged and I will commit and push the changes so that they are included (and will result in a successful AppVeyor build).