### PR TITLE
Migration fails when using SQL Server

### DIFF
--- a/core/Piranha/Data/Db.cs
+++ b/core/Piranha/Data/Db.cs
@@ -35,8 +35,12 @@ namespace Piranha.Data
                 Script = "Piranha.Data.Migrations.4.sql"
             },
             new DbMigration() {
-                Name = "RemoveMediaCache",
+                Name = "UpdateMediaTypes",
                 Script = "Piranha.Data.Migrations.5.sql"
+            },
+            new DbMigration() {
+                Name = "RemoveMediaCache",
+                Script = "Piranha.Data.Migrations.6.sql"
             }
         };
 

--- a/core/Piranha/Data/Migrations/5.sql
+++ b/core/Piranha/Data/Migrations/5.sql
@@ -7,4 +7,6 @@
 -- http://github.com/piranhacms/piranha
 -- 
 
-DELETE FROM [Piranha_Params] WHERE [Key] = 'CacheExpiresMedia';
+UPDATE [Piranha_Media] SET [Type] = 1 WHERE [ContentType] LIKE 'document/%' OR [ContentType] LIKE 'application/%';
+UPDATE [Piranha_Media] SET [Type] = 2 WHERE [ContentType] LIKE 'image/%';
+UPDATE [Piranha_Media] SET [Type] = 3 WHERE [ContentType] LIKE 'video/%';

--- a/core/Piranha/Data/Migrations/6.sql
+++ b/core/Piranha/Data/Migrations/6.sql
@@ -7,5 +7,4 @@
 -- http://github.com/piranhacms/piranha
 -- 
 
-ALTER TABLE [Piranha_Media] ADD [Type] INT NOT NULL DEFAULT(0);
-
+DELETE FROM [Piranha_Params] WHERE [Key] = 'CacheExpiresMedia';

--- a/core/Piranha/Extend/MediaManager.cs
+++ b/core/Piranha/Extend/MediaManager.cs
@@ -56,7 +56,7 @@ namespace Piranha.Extend
             /// <param name="extension">The file extension</param>
             /// <returns>If the extension exists</returns>
             public bool ContainsExtension(string extension) {
-                return this.Any(t => t.Extension == extension);
+                return this.Any(t => t.Extension.Equals(extension, System.StringComparison.OrdinalIgnoreCase));
             }
         }
 


### PR DESCRIPTION
This fixes #130 . Migration SQL scripts to SQL Server. When it comes to SQL Server you can execute the ALTER and UPDATE on the same table in the same script, the execution of the UPDATE will not be able to find the Table. The solution is to separate these two commands into separate queries.