### PR TITLE
Updated Pomelo EF Core Package version 2.1.1

### DIFF
--- a/core/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
+++ b/core/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.0" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.1.1" />
     <ProjectReference Include="..\Piranha\Piranha.csproj" />
     <ProjectReference Include="..\Piranha.AspNetCore.Identity\Piranha.AspNetCore.Identity.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Purpose

- Fixes #298 

### Changes

In `Piranha.AspNetCore.Identity.MySQL`:

- Updated `Pomelo.EntityFrameworkCore.MySql` to version `2.1.1`
- Updated `Microsoft.EntityFrameworkCore.Design` to version `2.1.1`
- Updated `Microsoft.AspNetCore.Identity.EntityFrameworkCore` to versin `2.1.1`

### Notes 

As the `Pomelo` package depends on `EF Core 2.1.1` I had to update the `EF Core` related packages in `Piranha.AspNetCore.Idenity.MySQL` to version `2.1.1`. A MySQL database was build without any issue using the example project. A new backend user could also be created and store - login worked as well. I therefore assume that other Piranha components are not effected by this update.