### PR TITLE
Add GetAll and GetAll<T> methods in IPostRepository and PostRepository.

### DIFF
--- a/core/Piranha/Repositories/IPostRepository.cs
+++ b/core/Piranha/Repositories/IPostRepository.cs
@@ -24,6 +24,18 @@ namespace Piranha.Repositories
         /// <summary>
         /// Gets the available post items.
         /// </summary>
+        /// <returns>The posts</returns>
+        IEnumerable<Models.DynamicPost> GetAll();
+
+        /// <summary>
+        /// Gets the available post items.
+        /// </summary>
+        /// <returns>The posts</returns>
+        IEnumerable<T> GetAll<T>() where T : Models.PostBase;
+
+        /// <summary>
+        /// Gets the available post items.
+        /// </summary>
         /// <param name="blogId">The unique id</param>
         /// <returns>The posts</returns>
         IEnumerable<Models.DynamicPost> GetAll(Guid blogId);

--- a/core/Piranha/Repositories/PostRepository.cs
+++ b/core/Piranha/Repositories/PostRepository.cs
@@ -49,6 +49,37 @@ namespace Piranha.Repositories
             return contentService.Create<T>(api.PostTypes.GetById(typeId));
         }        
 
+       /// <summary>
+        /// Gets the available posts for the specified blog.
+        /// </summary>
+        /// <returns>The posts</returns>
+        public IEnumerable<Models.DynamicPost> GetAll() {
+            return GetAll<Models.DynamicPost>();
+        }
+
+        /// <summary>
+        /// Gets the available post items.
+        /// </summary>
+        /// <returns>The posts</returns>
+        public IEnumerable<T> GetAll<T>() where T : Models.PostBase {
+            var posts = db.Posts
+                .AsNoTracking()
+                .OrderByDescending(p => p.Published)
+                .ThenByDescending(p => p.LastModified)
+                .ThenBy(p => p.Title)
+                .Select(p => p.Id);
+
+            var models = new List<T>();
+
+            foreach (var post in posts) {
+                var model = GetById<T>(post);
+
+                if (model != null)
+                    models.Add(model);
+            }
+            return models;
+        }
+
         /// <summary>
         /// Gets the available posts for the specified blog.
         /// </summary>

--- a/test/Piranha.Tests/Repositories/Posts.cs
+++ b/test/Piranha.Tests/Repositories/Posts.cs
@@ -280,6 +280,26 @@ namespace Piranha.Tests.Repositories
         }
 
         [Fact]
+        public void GetAll() {
+            using (var api = new Api(GetDb(), new ContentServiceFactory(services), storage, cache)) {
+                var posts = api.Posts.GetAll();
+
+                Assert.NotNull(posts);
+                Assert.NotEmpty(posts);
+            }
+        }
+
+        [Fact]
+        public void GetAllBaseClass() {
+            using (var api = new Api(GetDb(), new ContentServiceFactory(services), storage, cache)) {
+                var posts = api.Posts.GetAll<Models.PostBase>();
+
+                Assert.NotNull(posts);
+                Assert.NotEmpty(posts);
+            }
+        }
+
+        [Fact]
         public void GetAllById() {
             using (var api = new Api(GetDb(), new ContentServiceFactory(services), storage, cache)) {
                 var posts = api.Posts.GetAll(BLOG_ID);


### PR DESCRIPTION
Hello,

Me and my team we really like this amazing CMS and we try to integrate it to our already built web application.
In the process of integration we needed to show some posts, mainly the latest ones, in a page outside of the piranha cms domain. The problem that we faced was that there was no method, included in the api post repository, that fetches independently of an archive the posts.
That why I 've implemented these two methods, GetAll() and GetAll<T>().

I hope these changes do fit in the concept of the project. 