### PR TITLE
Add basePath and baseUrl parameters at AddPiranhaFileStorage extension method.

### DIFF
--- a/core/Piranha.Local.FileStorage/FileStorageExtensions.cs
+++ b/core/Piranha.Local.FileStorage/FileStorageExtensions.cs
@@ -21,9 +21,9 @@ public static class FileStorageExtensions
     /// <param name="scope">The optional service scope</param>
     /// <returns>The service collection</returns>
     public static IServiceCollection AddPiranhaFileStorage(this IServiceCollection services,
-        ServiceLifetime scope = ServiceLifetime.Singleton)
+        ServiceLifetime scope = ServiceLifetime.Singleton, string basePath = null, string baseUrl = null)
     {
-        services.Add(new ServiceDescriptor(typeof(IStorage), typeof(FileStorage), scope));
+        services.Add(new ServiceDescriptor(typeof(IStorage), sp => new FileStorage(basePath, baseUrl), scope));
 
         return services;
     }


### PR DESCRIPTION
In order to be able to control the folder where the media files get uploaded, it would be nice to pass the paths as parameters on AddPiranhaFileStorage service register.

Thank you very much.