### PR TITLE
When region has collection and only one field the title is always "Item"

### DIFF
--- a/core/Piranha.Manager/Areas/Manager/Services/PageEditService.cs
+++ b/core/Piranha.Manager/Areas/Manager/Services/PageEditService.cs
@@ -162,7 +162,8 @@ namespace Piranha.Areas.Manager.Services
                             itemTitle = ((Extend.IField)item).GetTitle();
                         if (string.IsNullOrWhiteSpace(itemTitle) && !string.IsNullOrWhiteSpace(region.ListTitlePlaceholder))
                             itemTitle = region.ListTitlePlaceholder;
-                        else itemTitle = "Item";
+                        else if (string.IsNullOrWhiteSpace(itemTitle))
+                            itemTitle = "Item";
                     }
 
                     var set = new PageEditFieldSet() {


### PR DESCRIPTION
Hello,

it took me a while to realize what was happening but in this scenario:

`[Region(Title = "Texts", ListPlaceholder = "New Text", SortOrder = 0)]`
` public IList<TextField> Texts { get; set; }`

when viewing it in the manager every item in this region collection was displayed with title "Item", it wasn't displaying the field title.