### PR TITLE
getting rid of compilation warning about specifying version

### DIFF
--- a/examples/MvcWeb/MvcWeb.csproj
+++ b/examples/MvcWeb/MvcWeb.csproj
@@ -9,7 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.4" />
   </ItemGroup>
 


### PR DESCRIPTION
as describe here: https://docs.microsoft.com/sv-se/dotnet/core/tools/csproj#implicit-package-references