### PR TITLE
Fixed DefaultIdentitySeed not adding users during initial setup

### DIFF
--- a/core/Piranha.AspNetCore.Identity/DefaultIdentitySeed.cs
+++ b/core/Piranha.AspNetCore.Identity/DefaultIdentitySeed.cs
@@ -47,7 +47,7 @@ namespace Piranha.AspNetCore.Identity
         /// </summary>
         public async Task CreateAsync()
         {
-            if (_db.Users.Any())
+            if (!_db.Users.Any())
             {
                 var user = new User
                 {


### PR DESCRIPTION
The test for whether any users exist missed a ! and only added a new identity if any already existed. Switched that with a ! and now a default user is created if none exist.