### PR TITLE
Meta Robots Information

### DIFF
--- a/core/Piranha.Manager/Areas/Manager/Views/Page/Partial/_BasicSettings.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Page/Partial/_BasicSettings.cshtml
@@ -26,6 +26,10 @@
                 @Html.TextAreaFor(m => m.MetaDescription, new { @class = "form-control small count-me", rows = 5, maxlength = 256, placeholder = "Meta description", style = "height:82px" })
                 <p>@(Model.MetaDescription != null ? Model.MetaDescription.Length : 0)/255</p>
             </div>
+            <div class="form-group">
+                <label>Meta Robots</label>
+                @Html.TextBoxFor(m => m.MetaRobots, new { @class = "form-control small", maxlength = 32, placeholder = "Meta robots" })
+            </div>
         }
         @if ((await Authorization.AuthorizeAsync(User, Piranha.Manager.Permission.PagesPublish)).Succeeded) {
             <div class="form-group">

--- a/core/Piranha.Manager/Areas/Manager/Views/Post/Edit.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Post/Edit.cshtml
@@ -355,6 +355,10 @@
                         <label>Meta Keywords</label>
                         @Html.TextBoxFor(m => m.MetaKeywords, new { @class = "form-control small", maxlength = 128, placeholder = "Meta keywords" })
                     </div>
+                    <div class="form-group">
+                        <label>Meta Robots</label>
+                        @Html.TextBoxFor(m => m.MetaRobots, new { @class = "form-control small", maxlength = 128, placeholder = "Meta robots" })
+                    </div>
                     @if ((await Authorization.AuthorizeAsync(User, Piranha.Manager.Permission.PostsPublish)).Succeeded) {
                         <div class="form-group">
                             <label>Publish date</label>

--- a/core/Piranha/Data/RoutedContent.cs
+++ b/core/Piranha/Data/RoutedContent.cs
@@ -31,6 +31,11 @@ namespace Piranha.Data
 	    public string MetaDescription { get; set; }
 
         /// <summary>
+        /// Gets/sets the optional meta robots.
+        /// </summary>
+        public string MetaRobots { get; set; }
+
+        /// <summary>
         /// Gets/sets the optional route.
         /// </summary>
 	    public string Route { get; set; }

--- a/core/Piranha/Db.cs
+++ b/core/Piranha/Db.cs
@@ -200,6 +200,7 @@ namespace Piranha
             mb.Entity<Data.Page>().Property(p => p.Slug).HasMaxLength(128).IsRequired();
             mb.Entity<Data.Page>().Property(p => p.MetaKeywords).HasMaxLength(128);
             mb.Entity<Data.Page>().Property(p => p.MetaDescription).HasMaxLength(256);
+            mb.Entity<Data.Page>().Property(p => p.MetaRobots).HasMaxLength(32);
             mb.Entity<Data.Page>().Property(p => p.Route).HasMaxLength(256);
             mb.Entity<Data.Page>().Property(p => p.RedirectUrl).HasMaxLength(256);
             mb.Entity<Data.Page>().HasIndex(p => new { p.SiteId, p.Slug }).IsUnique();
@@ -228,6 +229,7 @@ namespace Piranha
             mb.Entity<Data.Post>().Property(p => p.Slug).HasMaxLength(128).IsRequired();
             mb.Entity<Data.Post>().Property(p => p.MetaKeywords).HasMaxLength(128);
             mb.Entity<Data.Post>().Property(p => p.MetaDescription).HasMaxLength(256);
+            mb.Entity<Data.Post>().Property(p => p.MetaRobots).HasMaxLength(32);
             mb.Entity<Data.Post>().Property(p => p.Route).HasMaxLength(256);
             mb.Entity<Data.Post>().Property(p => p.RedirectUrl).HasMaxLength(256);
             mb.Entity<Data.Post>().HasOne(p => p.Category).WithMany().IsRequired().OnDelete(DeleteBehavior.Restrict);

--- a/core/Piranha/Migrations/20190105132037_AddMetaRobots.Designer.cs
+++ b/core/Piranha/Migrations/20190105132037_AddMetaRobots.Designer.cs
@@ -2,15 +2,17 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Piranha;
 
 namespace Piranha.Migrations
 {
     [DbContext(typeof(Db))]
-    partial class DbModelSnapshot : ModelSnapshot
+    [Migration("20190105132037_AddMetaRobots")]
+    partial class AddMetaRobots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/core/Piranha/Migrations/20190105132037_AddMetaRobots.cs
+++ b/core/Piranha/Migrations/20190105132037_AddMetaRobots.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Piranha.Migrations
+{
+    public partial class AddMetaRobots : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MetaRobots",
+                table: "Piranha_Posts",
+                maxLength: 32,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "MetaRobots",
+                table: "Piranha_Pages",
+                maxLength: 32,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MetaRobots",
+                table: "Piranha_Posts");
+
+            migrationBuilder.DropColumn(
+                name: "MetaRobots",
+                table: "Piranha_Pages");
+        }
+    }
+}

--- a/core/Piranha/Migrations/20190105132037_AddMetaRobots.cs
+++ b/core/Piranha/Migrations/20190105132037_AddMetaRobots.cs
@@ -2,6 +2,7 @@
 
 namespace Piranha.Migrations
 {
+    [NoCoverage]
     public partial class AddMetaRobots : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)

--- a/core/Piranha/Models/IMeta.cs
+++ b/core/Piranha/Models/IMeta.cs
@@ -26,5 +26,10 @@ namespace Piranha.Models
         /// Gets/sets the optional meta description.
         /// </summary>
         string MetaDescription { get; set; }
-    }
+
+        /// <summary>
+        /// Gets/sets the optional robots information
+        /// </summary>
+        string MetaRobots { get; set; }
+	}
 }

--- a/core/Piranha/Models/RoutedContent.cs
+++ b/core/Piranha/Models/RoutedContent.cs
@@ -38,6 +38,11 @@ namespace Piranha.Models
         public string MetaDescription { get; set; }
 
         /// <summary>
+        /// Gets/sets the optional robots.
+        /// </summary>
+        public string MetaRobots { get; set; }
+
+        /// <summary>
         /// Gets/sets the optional route used by the middleware.
         /// </summary>
         public string Route { get; set; }

--- a/examples/MvcWeb/Seed.cs
+++ b/examples/MvcWeb/Seed.cs
@@ -44,6 +44,7 @@ namespace MvcWeb
                 startpage.NavigationTitle = "Home";
                 startpage.MetaKeywords = "Piranha, Piranha CMS, CMS, AspNetCore, DotNetCore, MVC, .NET, .NET Core";
                 startpage.MetaDescription = "Piranha is the fun, fast and lightweight framework for developing cms-based web applications with AspNetCore.";
+                startpage.MetaRobots = "index,follow";
 
                 // Start page hero
                 startpage.Hero.Subtitle = "By developers - for developers";
@@ -162,6 +163,7 @@ namespace MvcWeb
                 blogpage.SortOrder = 2;
                 blogpage.MetaKeywords = "Piranha, Piranha CMS, CMS, AspNetCore, DotNetCore, MVC, Blog, News";
                 blogpage.MetaDescription = "Read the latest blog posts about Piranha, fast and lightweight framework for developing cms-based web applications with AspNetCore.";
+                blogpage.MetaRobots = "index,follow";
 
                 // Blog Hero
                 blogpage.Hero.Subtitle = "Blog Archive";

--- a/examples/MvcWeb/Views/Shared/Partial/_Meta.cshtml
+++ b/examples/MvcWeb/Views/Shared/Partial/_Meta.cshtml
@@ -2,6 +2,7 @@
 
 <meta name="keywords" content="@Model.MetaKeywords">
 <meta name="description" content="@Model.MetaDescription">
+<meta name="robots" content="@Model.MetaRobots">
 
 <meta name="og:type" content="article">
 <meta name="og:title" content="@Model.Title">

--- a/test/Piranha.Tests/Repositories/Pages.cs
+++ b/test/Piranha.Tests/Repositories/Pages.cs
@@ -142,7 +142,7 @@ namespace Piranha.Tests.Repositories
                     IsDefault = true
                 };
                 var emptysite = new Data.Site {
-                    Id = SITE_ID,
+                    Id = SITE_EMPTY_ID,
                     Title = "Empty Site",
                     InternalId = "EmptySite",
                     IsDefault = false


### PR DESCRIPTION
To have the possibility to manage the indexing / crawling behavior for different pages in different ways ("noindex/follow" for pages like imprint, data protection information and so on) it would be great to have the corresponding field in cms. As it is important and a global field i decided to have it in imeta and not in my custom page implementation using regions or so.

I decided not to implement a default value. this should be done in the view (meta).

