### PR TITLE
Features/issue512/audio content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ _Pvt_Extensions
 /examples/CoreWeb/wwwroot/uploads/0ed62253-d420-4121-8f8a-c9c58966c555-stopwatch.png
 /examples/CoreWeb/wwwroot/uploads/42be9216-67da-4ff6-a513-d77d2961e231-platform.png
 /examples/CoreWeb/wwwroot/uploads/d9d8a31b-2866-4344-b94c-20b7142f23b6-github.png
+/examples/MvcWeb/Properties/launchSettings.json

--- a/core/Piranha.Manager/Areas/Manager/Controllers/MediaController.cs
+++ b/core/Piranha.Manager/Areas/Manager/Controllers/MediaController.cs
@@ -259,6 +259,10 @@ namespace Piranha.Areas.Manager.Controllers
             {
                 type = MediaType.Video;
             }
+            else if (filter == "audio")
+            {
+                type = MediaType.Audio;
+            }
             return View("Modal", Models.MediaListModel.Get(_api, folderId, type));
         }
     }

--- a/core/Piranha.Manager/Areas/Manager/Views/Media/List.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Media/List.cshtml
@@ -184,6 +184,8 @@
                                     <span class="fas fa-film media-icon"></span>
                                 } else if (item.Type == MediaType.Document) {
                                     <span class="fas fa-book media-icon"></span>
+                                } else if (item.Type == MediaType.Audio) {
+                                    <span class="fas fa-headphones media-icon"></span>
                                 } else {
                                     <span class="fas fa-exclamation-triangle media-icon"></span>
                                 }

--- a/core/Piranha.Manager/Areas/Manager/Views/Media/Modal.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Media/Modal.cshtml
@@ -60,6 +60,8 @@
                                 <span class="fas fa-film media-icon"></span>
                             } else if (item.Type == MediaType.Document) {
                                 <span class="fas fa-book media-icon"></span>
+                            } else if (item.Type == MediaType.Audio) {
+                                <span class="fas fa-headphones media-icon"></span>
                             } else {
                                 <span class="fas fa-exclamation-triangle media-icon"></span>                                
                             }

--- a/core/Piranha.Manager/Areas/Manager/Views/Shared/EditorTemplates/AudioBlock.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Shared/EditorTemplates/AudioBlock.cshtml
@@ -1,0 +1,41 @@
+@model Piranha.Extend.Blocks.AudioBlock
+@{
+    var prefix = Html.ViewData.TemplateInfo.HtmlFieldPrefix
+        .Replace("[", "_").Replace("]", "_").Replace(".", "_");
+    var unique = "Audio_" + Guid.NewGuid().ToString();
+}
+
+<div class="block-audio">
+    <audio id="@(unique)_Preview" src="@(Model.Body.Media != null ? Url.Content(Model.Body.Media.PublicUrl) : "")" controls></audio>
+    <span class="audio-placeholder fas fa-headphones" ></span>
+    <div class="block-media-picker">
+        <div class="row">
+            <div class="col-xs-9">
+                @Html.HiddenFor(m => m.Body.Id)
+                <div class="well well-sm">
+                    <a id="@(unique)_Filename" href="#" data-toggle="modal">
+                        @if (Model.Body.Media != null) {
+                            @Model.Body.Media.Filename
+                        } else {
+                            <text>&nbsp;</text>
+                        }
+                    </a>
+                </div>
+            </div>
+            <div class="col-xs-3">
+                <div class="btn-group btn-group-justified" role="group">
+                    <div class="btn-group" role="group" style="padding-right:5px">
+                        <button class="btn btn-primary text-center" type="button" data-toggle="modal" data-target="#modalMedia" data-filter="audio" data-mediaid="@(prefix)_Body_Id" data-medianame="@(unique)_Filename" data-mediaurlid="@(unique)_Preview">
+                            <span class="fas fa-plus"></span>
+                        </button>
+                    </div>
+                    <div class="btn-group" role="group" style="padding-left:5px">
+                        <button class="btn btn-danger text-center btn-media-clear" type="button" data-mediaid="@(prefix)_Body_Id" data-medianame="@(unique)_Filename" data-mediaurlid="@(unique)_Preview">
+                            <span class="fas fa-times"></span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>  
+</div>

--- a/core/Piranha.Manager/Areas/Manager/Views/Shared/EditorTemplates/AudioField.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Shared/EditorTemplates/AudioField.cshtml
@@ -1,0 +1,28 @@
+﻿@model Piranha.Extend.Fields.AudioField
+@{
+    var prefix = Html.ViewData.TemplateInfo.HtmlFieldPrefix
+        .Replace("[", "_").Replace("]", "_").Replace(".", "_");
+}
+
+<div class="row">
+    <div class="col-xs-9">
+        @Html.HiddenFor(m => m.Id)
+        <div class="well well-sm">
+            <a id="@(prefix)_Filename" href="#" data-toggle="modal" data-target="#modalImgPreview" data-filename="@(Model.Media != null ? Model.Media.Filename : "")" data-url="@Url.Content(Model.Media != null ? Model.Media.PublicUrl : "")" data-contenttype="@Model.Media?.ContentType" data-filesize="@(Math.Round(Model.Media != null ? Model.Media.Size : 0 / (double)1024, 1))kB" data-modified="@Model.Media?.LastModified.ToString("yyyy-MM-dd")">@(Model.Media != null ? Model.Media.Filename : "")</a>
+        </div>
+    </div>
+    <div class="col-xs-3">
+        <div class="btn-group btn-group-justified" role="group">
+            <div class="btn-group" role="group" style="padding-right:5px">
+                <button class="btn btn-primary btn-block" type="button" data-toggle="modal" data-target="#modalMedia" data-filter="audio" data-mediaid="@(prefix)_Id" data-medianame="@(prefix)_Filename">
+                    <i class="fas fa-plus"></i>
+                </button>
+            </div>
+            <div class="btn-group" role="group" style="padding-left:5px">
+                <button class="btn btn-danger btn-block btn-media-clear" type="button" data-mediaid="@(prefix)_Id" data-medianame="@(prefix)_Filename">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/core/Piranha.Manager/Areas/Manager/Views/Shared/Partial/_PreviewModal.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Shared/Partial/_PreviewModal.cshtml
@@ -16,7 +16,15 @@
                         <video width="100%" controls>
                             <source src="" type="">
                             Your browser does not support the video tag.
-                        </video> 
+                        </video>
+                    </div>
+                </div>
+                <div id="previewAudio" class="row">
+                    <div class="col-sm-12">
+                        <video width="100%" controls>
+                            <source src="" type="">
+                            Your browser does not support the audio tag.
+                        </video>
                     </div>
                 </div>
                 <div id="previewDocument" class="row">

--- a/core/Piranha.Manager/Areas/Manager/Views/Shared/Partial/_PreviewModal.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Shared/Partial/_PreviewModal.cshtml
@@ -21,10 +21,10 @@
                 </div>
                 <div id="previewAudio" class="row">
                     <div class="col-sm-12">
-                        <video width="100%" controls>
+                        <audio width="100%" controls>
                             <source src="" type="">
                             Your browser does not support the audio tag.
-                        </video>
+                        </audio>
                     </div>
                 </div>
                 <div id="previewDocument" class="row">

--- a/core/Piranha.Manager/assets/js/piranha.media.js
+++ b/core/Piranha.Manager/assets/js/piranha.media.js
@@ -59,7 +59,7 @@ piranha.media = new function() {
             if (self.mediaUrlId) {
                 var mediaUrlCtrl = $("#" + self.mediaUrlId);
 
-                if (mediaUrlCtrl.prop("tagName") == "IMG" || mediaUrlCtrl.prop("tagName") == "VIDEO") {
+                if (mediaUrlCtrl.prop("tagName") == "IMG" || mediaUrlCtrl.prop("tagName") == "VIDEO" || mediaUrlCtrl.prop("tagname") == "AUDIO") {
                     mediaUrlCtrl.attr("src", e.data("url"));
                 } else {
                     mediaUrlCtrl.val(e.data("url"));
@@ -93,7 +93,7 @@ piranha.media = new function() {
 
             if (mediaUrlCtrl.prop("tagName") == "IMG") {
                 mediaUrlCtrl.attr("src", "/manager/assets/img/block-img-placeholder.png");
-            } else if (mediaUrlCtrl.prop("tagName") == "VIDEO") {
+            } else if (mediaUrlCtrl.prop("tagName") == "VIDEO" || mediaUrlCtrl.prop("tagName") == "AUDIO") {
                 mediaUrlCtrl.attr("src", "");
             }
         }
@@ -205,19 +205,30 @@ $("#modalImgPreview").on("show.bs.modal",
         if (contenttype.startsWith("image")) {
             modal.find("#previewImage").show();
             modal.find("#previewVideo").hide();
+            modal.find("#previewAudio").hide();
             modal.find("#previewDocument").hide();
 
             modal.find("#imgPreview").attr("alt", filename);
             modal.find("#imgPreview").attr("src", url);
         } else if (contenttype.startsWith("video")) {
             modal.find("#previewImage").hide();
+            modal.find("#previewAudio").hide();
             modal.find("#previewVideo").show();
             modal.find("#previewDocument").hide();
 
             modal.find("video").attr("src", url);
             modal.find("video").attr("type", contenttype);
+        } else if (contenttype.startsWith("audio")) {
+            modal.find("#previewImage").hide();
+            modal.find("#previewAudio").show();
+            modal.find("#previewVideo").hide();
+            modal.find("#previewDocument").hide();
+
+            modal.find("audio").attr("src", url);
+            modal.find("audio").attr("type", contenttype);
         } else if (contenttype === "application/pdf") {
             modal.find("#previewImage").hide();
+            modal.find("#previewAudio").hide();
             modal.find("#previewVideo").hide();
             modal.find("#previewDocument").show();
 

--- a/core/Piranha.Manager/assets/less/blocks.less
+++ b/core/Piranha.Manager/assets/less/blocks.less
@@ -341,6 +341,7 @@
         }
     }
 
+    .block-audio,
     .block-image,
     .block-video {
         background: @bg-color;
@@ -380,6 +381,30 @@
             display: none;
 
             & ~ .video-placeholder {
+                display: block !important;
+            }
+        }
+    }
+
+    .block-audio {
+        audio {
+            max-width: 100%;
+        }
+
+        audio ~ .audio-placeholder {
+            display: none;
+            font-size: 70px;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translateX(-50%) translateY(-50%);
+            color: #b5b5b5;
+        }
+
+        audio[src=""] {
+            display: none;
+
+            & ~ .audio-placeholder {
                 display: block !important;
             }
         }

--- a/core/Piranha/App.cs
+++ b/core/Piranha/App.cs
@@ -195,6 +195,8 @@ namespace Piranha
             Instance._mediaTypes.Images.Add(".jpeg", "image/jpeg");
             Instance._mediaTypes.Images.Add(".png", "image/png");
             Instance._mediaTypes.Videos.Add(".mp4", "video/mp4");
+            Instance._mediaTypes.Audios.Add(".mp3", "audio/mpeg");
+            Instance._mediaTypes.Audios.Add(".wav", "audio/wav");
 
             // Compose content types
             Instance._contentTypes.Register<Models.IPage>("Page", "Page");
@@ -214,6 +216,7 @@ namespace Piranha
             Instance._fields.Register<Extend.Fields.StringField>();
             Instance._fields.Register<Extend.Fields.TextField>();
             Instance._fields.Register<Extend.Fields.VideoField>();
+            Instance._fields.Register<Extend.Fields.AudioField>();
 
             // Compose block types
             Instance._blocks.Register<Extend.Blocks.HtmlBlock>();
@@ -222,6 +225,7 @@ namespace Piranha
             Instance._blocks.Register<Extend.Blocks.QuoteBlock>();
             Instance._blocks.Register<Extend.Blocks.TextBlock>();
             Instance._blocks.Register<Extend.Blocks.VideoBlock>();
+            Instance._blocks.Register<Extend.Blocks.AudioBlock>();
 
             // Compose serializers
             Instance._serializers.Register<Extend.Fields.CheckBoxField>(new CheckBoxFieldSerializer<Extend.Fields.CheckBoxField>());
@@ -237,6 +241,7 @@ namespace Piranha
             Instance._serializers.Register<Extend.Fields.TextField>(new StringFieldSerializer<Extend.Fields.TextField>());
             Instance._serializers.Register<Extend.Fields.ImageField>(new ImageFieldSerializer());
             Instance._serializers.Register<Extend.Fields.VideoField>(new VideoFieldSerializer());
+            Instance._serializers.Register<Extend.Fields.AudioField>(new AudioFieldSerializer());
 
             // Create markdown converter
             Instance._markdown = new DefaultMarkdown();

--- a/core/Piranha/Extend/Blocks/AudioBlock.cs
+++ b/core/Piranha/Extend/Blocks/AudioBlock.cs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2019 Filip Jansson
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ * 
+ * https://github.com/piranhacms/piranha.core
+ * 
+ */
+
+using Piranha.Extend.Fields;
+
+namespace Piranha.Extend.Blocks
+{
+    /// <summary>
+    /// Audio block.
+    /// </summary>
+    [BlockType(Name = "Audio", Category = "Media", Icon = "fas fa-headphones")]
+    public class AudioBlock : Block
+    {
+        /// <summary>
+        /// Gets/sets the Audio body.
+        /// </summary>
+        public AudioField Body { get; set; }
+    }
+}

--- a/core/Piranha/Extend/Fields/AudioField.cs
+++ b/core/Piranha/Extend/Fields/AudioField.cs
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018-2019 Håkan Edling
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core
+ *
+ */
+
+using System;
+using Piranha.Models;
+
+namespace Piranha.Extend.Fields
+{
+    [FieldType(Name = "Audio", Shorthand = "Audio")]
+    public class AudioField : MediaFieldBase<AudioField>
+    {
+        /// <summary>
+        /// Implicit operator for converting a Guid id to a field.
+        /// </summary>
+        /// <param name="str">The string value</param>
+        public static implicit operator AudioField(Guid guid)
+        {
+            return new AudioField { Id = guid };
+        }
+
+        /// <summary>
+        /// Implicit operator for converting a media object to a field.
+        /// </summary>
+        /// <param name="media">The media object</param>
+        public static implicit operator AudioField(Media media)
+        {
+            return new AudioField { Id = media.Id };
+        }
+
+        /// <summary>
+        /// Impicit operator for converting the field to an url string.
+        /// </summary>
+        /// <param name="image">The Audio field</param>
+        public static implicit operator string(AudioField image)
+        {
+            if (image.Media != null)
+            {
+                return image.Media.PublicUrl;
+            }
+            return "";
+        }
+    }
+}

--- a/core/Piranha/Extend/Serializers/AudioFieldSerializer.cs
+++ b/core/Piranha/Extend/Serializers/AudioFieldSerializer.cs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 Håkan Edling
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ * 
+ * https://github.com/piranhacms/piranha.core
+ * 
+ */
+
+using System;
+using Piranha.Extend.Fields;
+
+namespace Piranha.Extend.Serializers
+{
+    public class AudioFieldSerializer : ISerializer
+    {
+        /// <summary>
+        /// Serializes the given object.
+        /// </summary>
+        /// <param name="obj">The object</param>
+        /// <returns>The serialized value</returns>
+        public string Serialize(object obj)
+        {
+            if (obj is AudioField field)
+            {
+                return field.Id.ToString();
+            }
+            throw new ArgumentException("The given object doesn't match the serialization type");
+        }
+
+        /// <summary>
+        /// Deserializes the given string.
+        /// </summary>
+        /// <param name="str">The serialized value</param>
+        /// <returns>The object</returns>
+        public object Deserialize(string str)
+        {
+            return new AudioField
+            {
+                Id = !string.IsNullOrEmpty(str) ? new Guid(str) : (Guid?)null
+            };
+        }
+    }
+}

--- a/core/Piranha/Models/MediaType.cs
+++ b/core/Piranha/Models/MediaType.cs
@@ -17,6 +17,7 @@ namespace Piranha.Models
         Unknown,
         Document,
         Image,
-        Video
+        Video,
+        Audio
     }
 }

--- a/core/Piranha/Runtime/MediaManager.cs
+++ b/core/Piranha/Runtime/MediaManager.cs
@@ -79,6 +79,11 @@ namespace Piranha.Runtime
         public MediaTypeList Videos { get; set; } = new MediaTypeList();
 
         /// <summary>
+        /// Gets/sets the currently accepted audio extensions.
+        /// </summary>
+        public MediaTypeList Audios { get; set; } = new MediaTypeList();
+
+        /// <summary>
         /// Checks if the given filename has a supported extension.
         /// </summary>
         /// <param name="filename">The path or filename</param>
@@ -89,7 +94,8 @@ namespace Piranha.Runtime
 
             return Documents.ContainsExtension(extension) ||
                 Images.ContainsExtension(extension) ||
-                Videos.ContainsExtension(extension);
+                Videos.ContainsExtension(extension) ||
+                Audios.ContainsExtension(extension);
         }
 
         /// <summary>
@@ -113,6 +119,10 @@ namespace Piranha.Runtime
             else if (Videos.ContainsExtension(extension))
             {
                 return MediaType.Video;
+            }
+            else if (Audios.ContainsExtension(extension))
+            {
+                return MediaType.Audio;
             }
             return MediaType.Unknown;
         }
@@ -140,6 +150,11 @@ namespace Piranha.Runtime
             {
                 return item.ContentType;
             }
+            else if ((item = Audios.SingleOrDefault(t => t.Extension == extension)) != null)
+            {
+                return item.ContentType;
+            }
+
             return "application/octet-stream";
         }
     }

--- a/examples/MvcWeb/Views/Cms/DisplayTemplates/AudioBlock.cshtml
+++ b/examples/MvcWeb/Views/Cms/DisplayTemplates/AudioBlock.cshtml
@@ -1,0 +1,10 @@
+@model Piranha.Extend.Blocks.AudioBlock
+
+<div class="row justify-content-center">
+    <div class="col">
+        <audio width="100%" controls>
+            <source src="@Url.Content(Model.Body)" type="">
+            Your browser does not support the audio tag.
+        </audio>
+    </div>
+</div>

--- a/test/Piranha.Tests/Fields.cs
+++ b/test/Piranha.Tests/Fields.cs
@@ -430,6 +430,68 @@ namespace Piranha.Tests
         }
 
         [Fact]
+        public void AudioFieldConversions()
+        {
+            var media = new Media()
+            {
+                Id = Guid.NewGuid()
+            };
+
+            Piranha.Extend.Fields.AudioField field = media;
+            Assert.Equal(media.Id, field.Id.Value);
+        }
+
+        [Fact]
+        public async Task AudioFieldInitMissing()
+        {
+            using (var api = CreateApi())
+            {
+                var field = new Piranha.Extend.Fields.AudioField
+                {
+                    Id = Guid.NewGuid()
+                };
+
+                await field.Init(api);
+
+                Assert.Null(field.Id);
+            }
+        }
+
+        [Fact]
+        public void AudioFieldEquals()
+        {
+            var field1 = new Piranha.Extend.Fields.AudioField
+            {
+                Id = Guid.NewGuid()
+            };
+            var field2 = new Piranha.Extend.Fields.AudioField
+            {
+                Id = field1.Id
+            };
+
+            Assert.True(field1 == field2);
+            Assert.True(field1.Equals(field2));
+            Assert.True(field1.Equals((object)field2));
+        }
+
+        [Fact]
+        public void AudioFieldNotEquals()
+        {
+            var field1 = new Piranha.Extend.Fields.AudioField
+            {
+                Id = Guid.NewGuid()
+            };
+            var field2 = new Piranha.Extend.Fields.AudioField
+            {
+                Id = null
+            };
+
+            Assert.True(field1 != field2);
+            Assert.True(!field1.Equals(field2));
+            Assert.True(!field1.Equals((object)field2));
+        }
+
+        [Fact]
         public void MediaFieldConversions() {
             var media = new Media() {
                 Id = Guid.NewGuid()
@@ -507,6 +569,18 @@ namespace Piranha.Tests
             var id = Guid.NewGuid();
 
             Piranha.Extend.Fields.VideoField field = id;
+            Assert.Equal(id, field.Id.Value);
+
+            string url = field;
+            Assert.Equal("", url);
+        }
+
+        [Fact]
+        public void AudioFieldConversionsNullAudio()
+        {
+            var id = Guid.NewGuid();
+
+            Piranha.Extend.Fields.AudioField field = id;
             Assert.Equal(id, field.Id.Value);
 
             string url = field;

--- a/test/Piranha.Tests/Fields.cs
+++ b/test/Piranha.Tests/Fields.cs
@@ -432,7 +432,7 @@ namespace Piranha.Tests
         [Fact]
         public void AudioFieldConversions()
         {
-            var media = new Media()
+            var media = new Media
             {
                 Id = Guid.NewGuid()
             };

--- a/test/Piranha.Tests/MediaMgr.cs
+++ b/test/Piranha.Tests/MediaMgr.cs
@@ -31,6 +31,8 @@ namespace Piranha.Tests
             mgr.Images.Add(".jpeg", "image/jpeg");
             mgr.Images.Add(".png", "image/png");
             mgr.Videos.Add(".mp4", "video/mp4");
+            mgr.Audios.Add(".mp3", "audio/mp3");
+            mgr.Audios.Add(".wav", "audio/wav");
         }
 
         /// <summary>
@@ -65,6 +67,20 @@ namespace Piranha.Tests
         {
             var type = mgr.GetMediaType("myvideo.mp4");
             Assert.Equal(Models.MediaType.Video, type);
+        }
+
+        [Fact]
+        public void GetAudioMediaType()
+        {
+            var type = mgr.GetMediaType("myaudio.mp3");
+            Assert.Equal(Models.MediaType.Audio, type);
+        }
+
+        [Fact]
+        public void GetAudioContentType()
+        {
+            var type = mgr.GetContentType("myaudio.wav");
+            Assert.Equal("audio/wav", type);
         }
     }
 }

--- a/test/Piranha.Tests/MediaMgr.cs
+++ b/test/Piranha.Tests/MediaMgr.cs
@@ -31,7 +31,7 @@ namespace Piranha.Tests
             mgr.Images.Add(".jpeg", "image/jpeg");
             mgr.Images.Add(".png", "image/png");
             mgr.Videos.Add(".mp4", "video/mp4");
-            mgr.Audios.Add(".mp3", "audio/mp3");
+            mgr.Audios.Add(".mp3", "audio/mpeg");
             mgr.Audios.Add(".wav", "audio/wav");
         }
 

--- a/test/Piranha.Tests/Serializers.cs
+++ b/test/Piranha.Tests/Serializers.cs
@@ -251,7 +251,53 @@ namespace Piranha.Tests
                 Value = "Exception"
             }));
         }
+        // START AUDIO
+        [Fact]
+        public void SerializeAudioField()
+        {
+            var serializer = new AudioFieldSerializer();
+            var id = Guid.NewGuid();
 
+            var str = serializer.Serialize(new AudioField()
+            {
+                Id = id
+            });
+
+            Assert.Equal(id.ToString(), str);
+        }
+
+        [Fact]
+        public void DeserializeAudioField()
+        {
+            var serializer = new AudioFieldSerializer();
+            var id = Guid.NewGuid();
+
+            var field = (AudioField)serializer.Deserialize(id.ToString());
+
+            Assert.Equal(id, field.Id.Value);
+        }
+
+        [Fact]
+        public void DeserializeEmptyAudioField()
+        {
+            var serializer = new AudioFieldSerializer();
+
+            var field = (AudioField)serializer.Deserialize(null);
+
+            Assert.False(field.HasValue);
+        }
+
+        [Fact]
+        public void WrongInputToAudioField()
+        {
+            var serializer = new AudioFieldSerializer();
+
+            Assert.Throws<ArgumentException>(() => serializer.Serialize(new StringField()
+            {
+                Value = "Exception"
+            }));
+        }
+        // END AUDIO
         [Fact]
         public void SerializeMediaField() {
             var serializer = new MediaFieldSerializer();

--- a/test/Piranha.Tests/Serializers.cs
+++ b/test/Piranha.Tests/Serializers.cs
@@ -258,7 +258,7 @@ namespace Piranha.Tests
             var serializer = new AudioFieldSerializer();
             var id = Guid.NewGuid();
 
-            var str = serializer.Serialize(new AudioField()
+            var str = serializer.Serialize(new AudioField
             {
                 Id = id
             });


### PR DESCRIPTION
Hey @tidyui ,

As promised - first PR so feel free to roast me :-)

Points of note:

- It largely copies from the video control, like right down to copyright notice in the case of new files, and level of unit-testing included
- Went with **fa-headphones** for the icon but don't have any strong preference if you want to change it
- Added DisplayTemplate to the Examples/MvcWeb project, after reading a comment on issues that a similar Video display template will be added to there soon. Did not try bake a concrete example of an audio control into the example site though...
- For the MediaTypeList, went with somewhat awkward "Audios" rather than "Audio", just to keep it consistently plural across the MediaTypeLists.
- MIME type is "audio/mpeg" rather than "audio/mp3" ... based on [this RFC ](https://tools.ietf.org/html/rfc3003)

I think that's it - all feedback welcome...

Cheers,

Stephen