### PR TITLE
Added url unicode transliteration and additional unicode slug tests

### DIFF
--- a/core/Piranha/Piranha.csproj
+++ b/core/Piranha/Piranha.csproj
@@ -12,5 +12,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="Markdig" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Unidecode.NET" Version="1.4.0" />
   </ItemGroup>
 </Project>

--- a/core/Piranha/Utils.cs
+++ b/core/Piranha/Utils.cs
@@ -8,6 +8,7 @@
  *
  */
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -15,7 +16,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
-using Newtonsoft.Json;
+using Unidecode.NET;
 
 namespace Piranha
 {
@@ -60,22 +61,14 @@ namespace Piranha
             }
             else
             {
-                // Trim & make lower case
-                var slug = str.Trim().ToLower();
+                // Trim
+                var slug = str.Trim();
 
-                // Convert culture specific characters
-                slug = slug
-                    .Replace("å", "a")
-                    .Replace("ä", "a")
-                    .Replace("á", "a")
-                    .Replace("à", "a")
-                    .Replace("ö", "o")
-                    .Replace("ó", "o")
-                    .Replace("ò", "o")
-                    .Replace("é", "e")
-                    .Replace("è", "e")
-                    .Replace("í", "i")
-                    .Replace("ì", "i");
+                // Convert culture specific characters using transliteration library
+                slug = slug.Unidecode();
+
+                // To lowercase after transliteration
+                slug = slug.ToLower();
 
                 // Remove special characters
                 slug = Regex.Replace(slug, @"[^a-z0-9-/ ]", "").Replace("--", "-");

--- a/test/Piranha.Tests/Utils/Slug.cs
+++ b/test/Piranha.Tests/Utils/Slug.cs
@@ -42,7 +42,16 @@ namespace Piranha.Tests.Utils
 
         [Fact]
         public void RemoveSwedishCharacters() {
-            Assert.Equal("aaoaao", Piranha.Utils.GenerateSlug("åäöÅÄÖ"));
+            Assert.Equal("aaeoeaaeoe", Piranha.Utils.GenerateSlug("åäöÅÄÖ"));
+        }
+
+        [Fact]
+        public void TranslateUnicodeCharacters()
+        {
+            Assert.Equal("bei-jing", Piranha.Utils.GenerateSlug("北亰"));
+            Assert.Equal("bu-hao", Piranha.Utils.GenerateSlug("不好"));
+            Assert.Equal("kak-dela", Piranha.Utils.GenerateSlug("Как дела"));
+            Assert.Equal("ya-khotela-by-piva", Piranha.Utils.GenerateSlug("Я хотел(а) бы пива."));
         }
 
         [Fact]


### PR DESCRIPTION
In response to #566 

Uses Unidecode.NET nuget package to transliterate url segments prior to removing illegal characters and lowercase.

It does add a dependency to Piranha's core, so I'm open to similar alternatives that don't add a dependency. I believe the nuget package's licenses allows for us to copy this into Piranha if we wanted to eliminate the dependency. Unidecode itself hasn't had a major functionality update since 2012, I don't see it changing too much.