### PR TITLE
Make ArchiveRouter call GetBySlugAsync with typed class.

### DIFF
--- a/core/Piranha/Web/ArchiveRouter.cs
+++ b/core/Piranha/Web/ArchiveRouter.cs
@@ -31,7 +31,7 @@ namespace Piranha.Web
 
                 if (segments.Length >= 1)
                 {
-                    var blog = await api.Pages.GetBySlugAsync(segments[0], siteId)
+                    var blog = await api.Pages.GetBySlugAsync<Models.PageInfo>(segments[0], siteId)
                         .ConfigureAwait(false);
 
                     if (blog != null && blog.ContentType == "Blog")


### PR DESCRIPTION
This fixes issue #574, by specifying the `PageInfo` class when loading the archive page in the `ArchiveRouter`. This way the cache is utilized for getting the page info.