### PR TITLE
Fix null issues in field classes

### DIFF
--- a/core/Piranha/Extend/Fields/MediaFieldBase.cs
+++ b/core/Piranha/Extend/Fields/MediaFieldBase.cs
@@ -22,11 +22,7 @@ namespace Piranha.Extend.Fields
         /// </summary>
         public virtual string GetTitle()
         {
-            if (Media != null)
-            {
-                return Media.Filename;
-            }
-            return null;
+            return Media?.Filename;
         }
 
         /// <summary>
@@ -96,6 +92,10 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public virtual bool Equals(T obj)
         {
+            if (obj == null)
+            {
+                return false;
+            }
             return Id == obj.Id;
         }
 
@@ -107,7 +107,11 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator ==(MediaFieldBase<T> field1, MediaFieldBase<T> field2)
         {
-            return field1.Equals(field2);
+            if ((object)field1 != null && (object)field2 != null)
+            {
+                return field1.Equals(field2);
+            }
+            return false;
         }
 
         /// <summary>
@@ -118,7 +122,7 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator !=(MediaFieldBase<T> field1, MediaFieldBase<T> field2)
         {
-            return !field1.Equals(field2);
+            return !(field1 == field2);
         }
     }
 }

--- a/core/Piranha/Extend/Fields/PageField.cs
+++ b/core/Piranha/Extend/Fields/PageField.cs
@@ -41,9 +41,7 @@ namespace Piranha.Extend.Fields
         /// </summary>
         public virtual string GetTitle()
         {
-            if (Page != null)
-                return Page.Title;
-            return null;
+            return Page?.Title;
         }
 
         /// <summary>
@@ -126,6 +124,10 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public virtual bool Equals(PageField obj)
         {
+            if (obj == null)
+            {
+                return false;
+            }
             return Id == obj.Id;
         }
 
@@ -137,7 +139,11 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator ==(PageField field1, PageField field2)
         {
-            return field1.Equals(field2);
+            if ((object) field1 != null && (object) field2 != null)
+            {
+                return field1.Equals(field2);
+            }
+            return false;
         }
 
         /// <summary>
@@ -148,7 +154,7 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator !=(PageField field1, PageField field2)
         {
-            return !field1.Equals(field2);
+            return !(field1 == field2);
         }
     }
 }

--- a/core/Piranha/Extend/Fields/PageField.cs
+++ b/core/Piranha/Extend/Fields/PageField.cs
@@ -11,7 +11,6 @@
 using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
-using Piranha.Models;
 using Piranha.Services;
 
 namespace Piranha.Extend.Fields
@@ -29,7 +28,7 @@ namespace Piranha.Extend.Fields
         /// Gets/sets the related page object.
         /// </summary>
         [JsonIgnore]
-        public Models.PageBase Page { get; private set; }
+        public Models.DynamicPage Page { get; private set; }
 
         /// <summary>
         /// Gets if the field has a page object available.
@@ -54,7 +53,7 @@ namespace Piranha.Extend.Fields
             if (Id.HasValue)
             {
                 Page = await api.Pages
-                    .GetByIdAsync<PageBase>(Id.Value)
+                    .GetByIdAsync(Id.Value)
                     .ConfigureAwait(false);
 
                 if (Page == null)
@@ -73,7 +72,9 @@ namespace Piranha.Extend.Fields
         /// <returns>The referenced page</returns>
         public virtual Task<T> GetPageAsync<T>(IApi api) where T : Models.GenericPage<T>
         {
-            return Task.FromResult(Page as T);
+            if (Id.HasValue)
+                return api.Pages.GetByIdAsync<T>(Id.Value);
+            return null;
         }
 
         /// <summary>

--- a/core/Piranha/Extend/Fields/PageField.cs
+++ b/core/Piranha/Extend/Fields/PageField.cs
@@ -11,6 +11,7 @@
 using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
+using Piranha.Models;
 using Piranha.Services;
 
 namespace Piranha.Extend.Fields
@@ -28,7 +29,7 @@ namespace Piranha.Extend.Fields
         /// Gets/sets the related page object.
         /// </summary>
         [JsonIgnore]
-        public Models.DynamicPage Page { get; private set; }
+        public Models.PageBase Page { get; private set; }
 
         /// <summary>
         /// Gets if the field has a page object available.
@@ -53,7 +54,7 @@ namespace Piranha.Extend.Fields
             if (Id.HasValue)
             {
                 Page = await api.Pages
-                    .GetByIdAsync(Id.Value)
+                    .GetByIdAsync<PageBase>(Id.Value)
                     .ConfigureAwait(false);
 
                 if (Page == null)
@@ -72,9 +73,7 @@ namespace Piranha.Extend.Fields
         /// <returns>The referenced page</returns>
         public virtual Task<T> GetPageAsync<T>(IApi api) where T : Models.GenericPage<T>
         {
-            if (Id.HasValue)
-                return api.Pages.GetByIdAsync<T>(Id.Value);
-            return null;
+            return Task.FromResult(Page as T);
         }
 
         /// <summary>

--- a/core/Piranha/Extend/Fields/PostField.cs
+++ b/core/Piranha/Extend/Fields/PostField.cs
@@ -132,6 +132,10 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public virtual bool Equals(PostField obj)
         {
+            if (obj == null)
+            {
+                return false;
+            }
             return Id == obj.Id;
         }
 
@@ -143,7 +147,11 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator ==(PostField field1, PostField field2)
         {
-            return field1.Equals(field2);
+            if ((object)field1 != null && (object)field2 != null)
+            {
+                return field1.Equals(field2);
+            }
+            return false;
         }
 
         /// <summary>
@@ -154,7 +162,7 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator !=(PostField field1, PostField field2)
         {
-            return !field1.Equals(field2);
+            return !(field1 == field2);
         }
     }
 }

--- a/core/Piranha/Extend/Fields/PostField.cs
+++ b/core/Piranha/Extend/Fields/PostField.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Piranha.Models;
 using Piranha.Services;
 
 namespace Piranha.Extend.Fields
@@ -28,7 +29,7 @@ namespace Piranha.Extend.Fields
         /// Gets/sets the related post object.
         /// </summary>
         [JsonIgnore]
-        public Models.DynamicPost Post { get; private set; }
+        public Models.PostBase Post { get; private set; }
 
         /// <summary>
         /// Gets if the field has a post object available.
@@ -53,7 +54,7 @@ namespace Piranha.Extend.Fields
             if (Id.HasValue)
             {
                 Post = await api.Posts
-                    .GetByIdAsync(Id.Value)
+                    .GetByIdAsync<PostBase>(Id.Value)
                     .ConfigureAwait(false);
 
                 if (Post == null)
@@ -72,11 +73,7 @@ namespace Piranha.Extend.Fields
         /// <returns>The referenced post</returns>
         public virtual Task<T> GetPostAsync<T>(IApi api) where T : Models.Post<T>
         {
-            if (Id.HasValue)
-            {
-                return api.Posts.GetByIdAsync<T>(Id.Value);
-            }
-            return null;
+            return Task.FromResult(Post as T);
         }
 
         /// <summary>

--- a/core/Piranha/Extend/Fields/PostField.cs
+++ b/core/Piranha/Extend/Fields/PostField.cs
@@ -11,7 +11,6 @@
 using System;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Piranha.Models;
 using Piranha.Services;
 
 namespace Piranha.Extend.Fields
@@ -29,7 +28,7 @@ namespace Piranha.Extend.Fields
         /// Gets/sets the related post object.
         /// </summary>
         [JsonIgnore]
-        public Models.PostBase Post { get; private set; }
+        public Models.DynamicPost Post { get; private set; }
 
         /// <summary>
         /// Gets if the field has a post object available.
@@ -54,7 +53,7 @@ namespace Piranha.Extend.Fields
             if (Id.HasValue)
             {
                 Post = await api.Posts
-                    .GetByIdAsync<PostBase>(Id.Value)
+                    .GetByIdAsync(Id.Value)
                     .ConfigureAwait(false);
 
                 if (Post == null)
@@ -73,7 +72,11 @@ namespace Piranha.Extend.Fields
         /// <returns>The referenced post</returns>
         public virtual Task<T> GetPostAsync<T>(IApi api) where T : Models.Post<T>
         {
-            return Task.FromResult(Post as T);
+            if (Id.HasValue)
+            {
+                return api.Posts.GetByIdAsync<T>(Id.Value);
+            }
+            return null;
         }
 
         /// <summary>

--- a/core/Piranha/Extend/Fields/SelectField.cs
+++ b/core/Piranha/Extend/Fields/SelectField.cs
@@ -114,6 +114,10 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public virtual bool Equals(SelectField<T> obj)
         {
+            if (obj == null)
+            {
+                return false;
+            }
             return EqualityComparer<T>.Default.Equals(Value, obj.Value);
         }
 
@@ -125,7 +129,11 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator ==(SelectField<T> field1, SelectField<T> field2)
         {
-            return field1.Equals(field2);
+            if ((object)field1 != null && (object)field2 != null)
+            {
+                return field1.Equals(field2);
+            }
+            return false;
         }
 
         /// <summary>
@@ -136,7 +144,11 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator !=(SelectField<T> field1, SelectField<T> field2)
         {
-            return !field1.Equals(field2);
+            if ((object)field1 != null && (object)field2 != null)
+            {
+                return field1.Equals(field2);
+            }
+            return false;
         }
 
         /// <summary>

--- a/core/Piranha/Extend/Fields/SimpleField.cs
+++ b/core/Piranha/Extend/Fields/SimpleField.cs
@@ -72,6 +72,10 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public virtual bool Equals(SimpleField<T> obj)
         {
+            if (obj == null)
+            {
+                return false;
+            }
             return EqualityComparer<T>.Default.Equals(Value, obj.Value);
         }
 
@@ -83,7 +87,11 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator ==(SimpleField<T> field1, SimpleField<T> field2)
         {
-            return field1.Equals(field2);
+            if ((object)field1 != null && (object)field2 != null)
+            {
+                return field1.Equals(field2);
+            }
+            return false;
         }
 
         /// <summary>
@@ -94,7 +102,7 @@ namespace Piranha.Extend.Fields
         /// <returns>True if the fields are equal</returns>
         public static bool operator !=(SimpleField<T> field1, SimpleField<T> field2)
         {
-            return !field1.Equals(field2);
+            return !(field1 == field2);
         }
     }
 }


### PR DESCRIPTION
This fixes issue #572, by adding null-checks to equality methods in field classes.
Also changes initialization of `PageField` and `PostField` to load typed `PageBase` and `PostBase`, respectively, instead of `DynamicPage` and `DynamicPost`. This way content can be fetched from cache.