### PR TITLE
Make ArchiveRouter supports trailing slash.

### DIFF
--- a/core/Piranha/Web/ArchiveRouter.cs
+++ b/core/Piranha/Web/ArchiveRouter.cs
@@ -27,7 +27,7 @@ namespace Piranha.Web
         {
             if (!String.IsNullOrWhiteSpace(url) && url.Length > 1)
             {
-                var segments = url.Substring(1).Split(new char[] { '/' });
+                var segments = url.Substring(1).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (segments.Length >= 1)
                 {

--- a/core/Piranha/Web/PageRouter.cs
+++ b/core/Piranha/Web/PageRouter.cs
@@ -27,7 +27,7 @@ namespace Piranha.Web
         {
             if (!String.IsNullOrWhiteSpace(url) && url.Length > 1)
             {
-                var segments = url.Substring(1).Split(new char[] { '/' });
+                var segments = url.Substring(1).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
                 var include = segments.Length;
 

--- a/core/Piranha/Web/PostRouter.cs
+++ b/core/Piranha/Web/PostRouter.cs
@@ -27,7 +27,7 @@ namespace Piranha.Web
         {
             if (!String.IsNullOrWhiteSpace(url) && url.Length > 1)
             {
-                var segments = url.Substring(1).Split(new char[] { '/' });
+                var segments = url.Substring(1).Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
 
                 if (segments.Length >= 2)
                 {


### PR DESCRIPTION
This is a quick-fix to #580. It works by remove empty segments when splitting the URL into a string array. When the URL ends with a trailing slash, it would add an empty segment, which the router would try to parse into a year, which fails.
By ignoring the empty segment, it works as before with and without trailing slash.