### PR TITLE
Manually render CheckBoxFor() hidden field

### DIFF
--- a/core/Piranha.Manager/Areas/Manager/Views/Shared/EditorTemplates/CheckBoxField.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Views/Shared/EditorTemplates/CheckBoxField.cshtml
@@ -2,8 +2,16 @@
 @{
     var placeholder = ViewData["Placeholder"];    
 }
+
 <div class="checkbox">
-    <label>
-        @Html.CheckBoxFor(m => m.Value, new { @class = "checkbox" }) @placeholder
-    </label>
+	<label>
+		<input 
+			   id="@Html.IdFor(m => m.Value)"
+			   name="@Html.NameFor(m => m.Value)"
+			   type="checkbox"
+			   @(Model.Value ? "checked=\"checked\"" : "")
+			   value="true"> @placeholder
+	</label>
+
+	<input name="@Html.NameFor(m => m.Value)" type="hidden" value="false">
 </div>


### PR DESCRIPTION
From #585, checkbox fields render using the default Html.CheckBoxFor(), which according to https://stackoverflow.com/questions/2697299/asp-net-mvc-why-is-html-checkbox-generating-an-additional-hidden-input (and I guess makes sense) that the field is generated because a <input type=checkbox /> without a checked value is not included when a form is serialized. A hidden field with the same name lower in the form so that when it's serialized, it'll always have a value in the serialized json even if not checked.

As @tidyui mentioned, the javascript for the manager, when reordering blocks, keeps input name attributes updated by changing them when a block is moved or a new block is added before a certain block. Unfortunately, this fails because the default hidden field is actually rendered at the very bottom of the form, outside of the scope that the current manager JS updates input names when blocks are recalculated.

That said, to fix it, there are a few options (two javascript-based, one markup option):
1. Change the javascript file for the UI to either consider field following a pattern (Blocks[#]) or..
2. Within the JS script of recalculation, if the input type is "checkbox" that it finds within the field editor, look for an identically-named field as a child of the parent form and change it's name or...
3. Leave the manager javascript alone, and just manually render the hidden field within the context of the field so that all works as it normally would, just with a manually-rendered field

This solution is the third option above. I didn't want to modify the javascript for the editor knowing there may be fields and blocks I do not know about. I opted for this option also so it would nearly identically replicate what the html helper method outputs, just reordered in the markup to fit within the block editor.

I have merged this into https://github.com/i-love-code/piranha.core/commits/reproduction/custom-block-saving the reproduction branch as a test and just verified it's functionality. Hopefully this is a short term solution for blocks without custom renderers and checkboxes.