### PR TITLE
Add caching of aliases when not found

### DIFF
--- a/core/Piranha.AspNetCore/AliasMiddleware.cs
+++ b/core/Piranha.AspNetCore/AliasMiddleware.cs
@@ -44,7 +44,7 @@ namespace Piranha.AspNetCore
             var response = await AliasRouter.InvokeAsync(api, url, service.Site.Id);
             if (response == null)
             {
-                _logger.LogTrace("No alias was found. URL: {0}.", url);
+                _logger?.LogTrace("No alias was found. URL: {0}.", url);
 
                 await _next.Invoke(context);
                 return;

--- a/core/Piranha/Utils.cs
+++ b/core/Piranha/Utils.cs
@@ -210,7 +210,16 @@ namespace Piranha
         public static T DeepClone<T>(T obj)
         {
             if (obj == null)
+            {
+                // Null value does not need to be cloned.
+                return default(T);
+            }
+
+            if (obj is ValueType)
+            {
+                // Value types do not need to be cloned.
                 return obj;
+            }
 
             var settings = new JsonSerializerSettings
             {

--- a/core/Piranha/Web/AliasRouter.cs
+++ b/core/Piranha/Web/AliasRouter.cs
@@ -10,7 +10,6 @@
 
 using System;
 using System.Threading.Tasks;
-using Piranha.Services;
 
 namespace Piranha.Web
 {
@@ -25,23 +24,25 @@ namespace Piranha.Web
         /// <returns>The piranha response, null if no matching page was found</returns>
         public static async Task<IRouteResponse> InvokeAsync(IApi api, string url, Guid siteId)
         {
-            if (!String.IsNullOrWhiteSpace(url) && url.Length > 1)
+            if (string.IsNullOrWhiteSpace(url) || url.Length <= 1)
             {
-                // Check if we can find an alias with the requested url
-                var alias = await api.Aliases.GetByAliasUrlAsync(url, siteId)
-                    .ConfigureAwait(false);
-
-                if (alias != null)
-                {
-                    return new RouteResponse
-                    {
-                        IsPublished = true,
-                        RedirectUrl = alias.RedirectUrl,
-                        RedirectType = alias.Type
-                    };
-                }
+                return null;
             }
-            return null;
+
+            // Check if we can find an alias with the requested url
+            var alias = await api.Aliases.GetByAliasUrlAsync(url, siteId)
+                .ConfigureAwait(false);
+            if (alias == null)
+            {
+                return null;
+            }
+
+            return new RouteResponse
+            {
+                IsPublished = true,
+                RedirectUrl = alias.RedirectUrl,
+                RedirectType = alias.Type
+            };
         }
     }
 }

--- a/test/Piranha.Tests/Utils/DeepClone.cs
+++ b/test/Piranha.Tests/Utils/DeepClone.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Piranha.Models;
+using Xunit;
+
+namespace Piranha.Tests.Utils
+{
+    public class DeepClone
+    {
+        [Fact]
+        public void WithBoolean()
+        {
+            bool parameter = true;
+
+            bool result = Piranha.Utils.DeepClone(parameter);
+            parameter = false;
+
+            // Result should be true and changing 'parameter' should not affect 'result'.
+            Assert.True(result);
+            Assert.NotEqual(parameter, result);
+        }
+
+        [Fact]
+        public void WithAliasNull()
+        {
+            Alias alias = null;
+
+            Alias result = Piranha.Utils.DeepClone(alias);
+            alias = new Alias();
+
+            // Result should be null and not referentially equal to 'parameter'.
+            Assert.Null(result);
+            Assert.NotEqual(alias, result);
+        }
+
+        [Fact]
+        public void WithAliasObject()
+        {
+            Alias alias = new Alias();
+
+            Alias result = Piranha.Utils.DeepClone<Alias>(alias);
+            alias.Id = Guid.NewGuid();
+
+            // Result should not be null true and not referentially equal to 'parameter'.
+            Assert.NotNull(result);
+            Assert.NotEqual(alias, result);
+        }
+    }
+}


### PR DESCRIPTION
This implements #587 by adding an empty ID value (00000000-0000-0000-0000-000000000000) for the alias cache key, when an alias was not found in the database.
On next look up in the cache (by SiteId and Slug) this empty value is returned instead of null. This means that the slug was already looked up in the database, and no alias was found at the time.
When an actual alias is added the same cache key will be removed from the cache. On next request the actual alias will be loaded and added to the cache.
When an alias is removed, the cache key is removed, too. And on next request the empty value will be added to the cache.

I also added a minor tweak to the DeepClone method.
When the parameter passed into the method is a struct/value-type the method, then it will return the same value (no cloning), since only reference types need cloning.

Let me know your thoughts about the solution.