### PR TITLE
Optimize deep cloning for value types

### DIFF
--- a/core/Piranha/Utils.cs
+++ b/core/Piranha/Utils.cs
@@ -210,7 +210,16 @@ namespace Piranha
         public static T DeepClone<T>(T obj)
         {
             if (obj == null)
+            {
+                // Null value does not need to be cloned.
+                return default(T);
+            }
+
+            if (obj is ValueType)
+            {
+                // Value types do not need to be cloned.
                 return obj;
+            }
 
             var settings = new JsonSerializerSettings
             {

--- a/test/Piranha.Tests/Utils/DeepClone.cs
+++ b/test/Piranha.Tests/Utils/DeepClone.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Piranha.Models;
+using Xunit;
+
+namespace Piranha.Tests.Utils
+{
+    public class DeepClone
+    {
+        [Fact]
+        public void WithBoolean()
+        {
+            bool parameter = true;
+
+            bool result = Piranha.Utils.DeepClone(parameter);
+            parameter = false;
+
+            // Result should be true and changing 'parameter' should not affect 'result'.
+            Assert.True(result);
+            Assert.NotEqual(parameter, result);
+        }
+
+        [Fact]
+        public void WithAliasNull()
+        {
+            Alias alias = null;
+
+            Alias result = Piranha.Utils.DeepClone(alias);
+            alias = new Alias();
+
+            // Result should be null and not referentially equal to 'parameter'.
+            Assert.Null(result);
+            Assert.NotEqual(alias, result);
+        }
+
+        [Fact]
+        public void WithAliasObject()
+        {
+            Alias alias = new Alias();
+
+            Alias result = Piranha.Utils.DeepClone<Alias>(alias);
+            alias.Id = Guid.NewGuid();
+
+            // Result should not be null true and not referentially equal to 'parameter'.
+            Assert.NotNull(result);
+            Assert.NotEqual(alias, result);
+        }
+    }
+}


### PR DESCRIPTION
When the parameter passed into the method is a struct/value-type the method, then it will return the same value (no cloning), since only reference types need cloning.