### PR TITLE
Add SRI support for custom manager scripts

### DIFF
--- a/Piranha.sln
+++ b/Piranha.sln
@@ -70,11 +70,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piranha.Data.EF", "data\Pir
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piranha.Manager.Core", "core\Piranha.Manager.Core\Piranha.Manager.Core.csproj", "{96510F63-4191-494B-B4A3-6C0497837F6A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piranha.Manager", "core\Piranha.Manager\Piranha.Manager.csproj", "{A21B74AB-86CF-4AC6-87D6-A99656F8D2A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piranha.Manager", "core\Piranha.Manager\Piranha.Manager.csproj", "{A21B74AB-86CF-4AC6-87D6-A99656F8D2A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piranha.Manager.Localization", "core\Piranha.Manager.Localization\Piranha.Manager.Localization.csproj", "{22D8ED84-0A3B-4A02-B17B-ED8839323CCC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piranha.Manager.Localization", "core\Piranha.Manager.Localization\Piranha.Manager.Localization.csproj", "{22D8ED84-0A3B-4A02-B17B-ED8839323CCC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Piranha.WebApi", "core\Piranha.WebApi\Piranha.WebApi.csproj", "{D61EFBBC-5DB5-4810-9FE7-B9FE0C47A035}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piranha.WebApi", "core\Piranha.WebApi\Piranha.WebApi.csproj", "{D61EFBBC-5DB5-4810-9FE7-B9FE0C47A035}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Prianha.Manager.Tests", "test\Prianha.Manager.Tests\Prianha.Manager.Tests.csproj", "{1CB2D174-70D8-4F51-A131-81C43E0FFEA5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -162,6 +164,10 @@ Global
 		{D61EFBBC-5DB5-4810-9FE7-B9FE0C47A035}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D61EFBBC-5DB5-4810-9FE7-B9FE0C47A035}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D61EFBBC-5DB5-4810-9FE7-B9FE0C47A035}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CB2D174-70D8-4F51-A131-81C43E0FFEA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CB2D174-70D8-4F51-A131-81C43E0FFEA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CB2D174-70D8-4F51-A131-81C43E0FFEA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CB2D174-70D8-4F51-A131-81C43E0FFEA5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -187,6 +193,7 @@ Global
 		{A21B74AB-86CF-4AC6-87D6-A99656F8D2A0} = {42A64587-89B5-48F2-84D4-85B97F7847F1}
 		{22D8ED84-0A3B-4A02-B17B-ED8839323CCC} = {42A64587-89B5-48F2-84D4-85B97F7847F1}
 		{D61EFBBC-5DB5-4810-9FE7-B9FE0C47A035} = {42A64587-89B5-48F2-84D4-85B97F7847F1}
+		{1CB2D174-70D8-4F51-A131-81C43E0FFEA5} = {DE1913AC-4AA3-4F66-83F1-615710D8367B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {CF88AA05-D127-4707-8214-A230F0DA569B}

--- a/core/Piranha.Manager/Areas/Manager/Shared/_Layout.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Shared/_Layout.cshtml
@@ -58,9 +58,13 @@
             //Url.Content does not error on absolute paths, so no additional logic needs to be taken here.
             <script type="@script.Type" src="@Url.Content(script.Src)"></script>
         }
+        else if (script.CrossOriginValue == ECrossOriginPolicy.None)
+        {
+            <script type="@script.Type" src="@Url.Content(script.Src)" integrity="@script.Integrity"></script>
+        }
         else
         {
-            <script type="@script.Type" src="@Url.Content(script.Src)" integrity="@script.Integrity" crossorigin="@(script.CrossOriginUseCredentials? "use-credentials":"anonymous")"></script>
+            <script type="@script.Type" src="@Url.Content(script.Src)" integrity="@script.Integrity" crossorigin="@script.GetCrossOriginValueStrValue()"></script>
         }
     }
     @RenderSection("script", required: false)

--- a/core/Piranha.Manager/Areas/Manager/Shared/_Layout.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Shared/_Layout.cshtml
@@ -40,19 +40,28 @@
     <script src="~/manager/assets/js/piranha.min.js"></script>
     @if (!string.IsNullOrWhiteSpace(ViewBag.Message))
     {
-    <script>
+        <script>
         piranha.notifications.push({
             body: "@Html.Raw(ViewBag.Message)",
             type: "@Html.Raw(ViewBag.MessageCss)",
             hide: true
         });
-    </script>
+        </script>
     }
 
     <partial name="~/Areas/Manager/Shared/Partial/_Resources.cshtml" />
 
-    @foreach (var script in module.Scripts) {
-    <script type="text/javascript" src="@Url.Content(script)"></script>
+    @foreach (var script in module.Scripts)
+    {
+        if (string.IsNullOrWhiteSpace(script.Integrity))
+        {
+            //Url.Content does not error on absolute paths, so no additional logic needs to be taken here.
+            <script type="@script.Type" src="@Url.Content(script.Src)"></script>
+        }
+        else
+        {
+            <script type="@script.Type" src="@Url.Content(script.Src)" integrity="@script.Integrity" crossorigin="@(script.CrossOriginUseCredentials? "use-credentials":"anonymous")"></script>
+        }
     }
     @RenderSection("script", required: false)
 </body>

--- a/core/Piranha.Manager/ManagerScriptDefinition.cs
+++ b/core/Piranha.Manager/ManagerScriptDefinition.cs
@@ -6,6 +6,13 @@ using Microsoft.AspNetCore.Routing.Constraints;
 namespace Piranha.Manager
 {
 
+    public enum ECrossOriginPolicy
+    {
+        None,
+        Anonymous,
+        UseCredentials
+    }
+
     /// <summary>
     /// Defines custom script resources with sources, hashes, and other future features as needed.
     /// </summary>
@@ -24,7 +31,22 @@ namespace Piranha.Manager
         /// <summary>
         /// If true, set crossorigin to "use-credentials". Otherwise, set to "anonymous".
         /// </summary>
-        public bool CrossOriginUseCredentials { get; }
+        public ECrossOriginPolicy CrossOriginValue { get; }
+
+        public string GetCrossOriginValueStrValue(bool includeAttributeName = false)
+        {
+            switch (CrossOriginValue)
+            {
+                case ECrossOriginPolicy.None:
+                    return "";
+                case ECrossOriginPolicy.Anonymous:
+                    return includeAttributeName ? "crossorigin=\"anonymous\"": "anonymous";
+                case ECrossOriginPolicy.UseCredentials:
+                    return includeAttributeName ? "crossorigin=\"use-credentials\"" : "use-credentials";
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+        }
 
         /// <summary>
         /// The script type.
@@ -38,13 +60,13 @@ namespace Piranha.Manager
         /// <returns></returns>
         public override int GetHashCode() => Integrity?.GetHashCode() ?? Src.GetHashCode();
 
-        public ManagerScriptDefinition(string src, string integrity = null, bool crossOriginUseCredentials = false, string type = "text/javascript")
+        public ManagerScriptDefinition(string src, string integrity = null, ECrossOriginPolicy crossOriginValue = ECrossOriginPolicy.Anonymous, string type = "text/javascript")
         {
             if (src == null) throw new ArgumentNullException(nameof(src));
             if (string.IsNullOrWhiteSpace(src)) throw new ArgumentException("Source url must not be null or whitespace.", nameof(src));
             Src = src;
             Integrity = integrity;
-            CrossOriginUseCredentials = crossOriginUseCredentials;
+            CrossOriginValue = crossOriginValue;
             Type = type;
         }
 
@@ -53,7 +75,7 @@ namespace Piranha.Manager
         /// Returns a text string of what a rendered script tag for this script would look like.
         /// </summary>
         /// <returns></returns>
-        public override string ToString() => $"<script type=\"{Type}\" src=\"{Src}\"{(string.IsNullOrWhiteSpace(Integrity) ? "":$" integrity=\"{Integrity}\" crossorigin=\"{(CrossOriginUseCredentials ? "use-credentials":"anonymous")}\"")}></script>";
+        public override string ToString() => $"<script type=\"{Type}\" src=\"{Src}\"{(string.IsNullOrWhiteSpace(Integrity) ? "":$" integrity=\"{Integrity}\" {GetCrossOriginValueStrValue(true)}")}></script>";
 
         /// <summary>
         /// Backwards compatibility for the original string list.

--- a/core/Piranha.Manager/ManagerScriptDefinition.cs
+++ b/core/Piranha.Manager/ManagerScriptDefinition.cs
@@ -52,9 +52,6 @@ namespace Piranha.Manager
         /// </summary>
         public string Type { get; }
 
-        
-        
-
         /// <summary>
         /// Get the hash code for this script.
         /// </summary>

--- a/core/Piranha.Manager/ManagerScriptDefinition.cs
+++ b/core/Piranha.Manager/ManagerScriptDefinition.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Routing.Constraints;
 
 namespace Piranha.Manager
 {
-
     public enum ECrossOriginPolicy
     {
         None,
@@ -16,7 +15,7 @@ namespace Piranha.Manager
     /// <summary>
     /// Defines custom script resources with sources, hashes, and other future features as needed.
     /// </summary>
-    public class ManagerScriptDefinition
+    public class ManagerScriptDefinition : IEquatable<ManagerScriptDefinition>
     {
         /// <summary>
         /// The script source.
@@ -53,17 +52,34 @@ namespace Piranha.Manager
         /// </summary>
         public string Type { get; }
 
+        
+        
+
         /// <summary>
         /// Get the hash code for this script.
         /// </summary>
         /// <remarks>The integrity hash will still be unique to the file, even moreso than the address. If the same file gets loaded with SRI hashes from two different sources they'll still be labeled the same file.</remarks>
         /// <returns></returns>
-        public override int GetHashCode() => Integrity?.GetHashCode() ?? Src.GetHashCode();
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((Src != null ? Src.GetHashCode() : 0) * 397) ^ (Integrity != null ? Integrity.GetHashCode() : 0);
+            }
+        }
 
         public ManagerScriptDefinition(string src, string integrity = null, ECrossOriginPolicy crossOriginValue = ECrossOriginPolicy.Anonymous, string type = "text/javascript")
         {
-            if (src == null) throw new ArgumentNullException(nameof(src));
-            if (string.IsNullOrWhiteSpace(src)) throw new ArgumentException("Source url must not be null or whitespace.", nameof(src));
+            if (src == null)
+            {
+                throw new ArgumentNullException(nameof(src));
+            }
+
+            if (string.IsNullOrWhiteSpace(src))
+            {
+                throw new ArgumentException("Source url must not be null or whitespace.", nameof(src));
+            }
+
             Src = src;
             Integrity = integrity;
             CrossOriginValue = crossOriginValue;
@@ -88,5 +104,34 @@ namespace Piranha.Manager
         /// </summary>
         /// <param name="valTup"></param>
         public static implicit operator ManagerScriptDefinition((string src, string integrity) valTup) => new ManagerScriptDefinition(valTup.src, valTup.integrity);
+
+        public bool Equals(ManagerScriptDefinition other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+            return Integrity == null ? Src == other.Src : Integrity == other.Integrity;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == this.GetType() && Equals((ManagerScriptDefinition) obj);
+        }
     }
 }

--- a/core/Piranha.Manager/ManagerScriptDefinition.cs
+++ b/core/Piranha.Manager/ManagerScriptDefinition.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.AspNetCore.Routing.Constraints;
+
+namespace Piranha.Manager
+{
+
+    /// <summary>
+    /// Defines custom script resources with sources, hashes, and other future features as needed.
+    /// </summary>
+    public class ManagerScriptDefinition
+    {
+        /// <summary>
+        /// The script source.
+        /// </summary>
+        public string Src { get; }
+
+        /// <summary>
+        /// The file hash.
+        /// </summary>
+        public string Integrity { get; }
+
+        /// <summary>
+        /// If true, set crossorigin to "use-credentials". Otherwise, set to "anonymous".
+        /// </summary>
+        public bool CrossOriginUseCredentials { get; }
+
+        /// <summary>
+        /// The script type.
+        /// </summary>
+        public string Type { get; }
+
+        /// <summary>
+        /// Get the hash code for this script.
+        /// </summary>
+        /// <remarks>The integrity hash will still be unique to the file, even moreso than the address. If the same file gets loaded with SRI hashes from two different sources they'll still be labeled the same file.</remarks>
+        /// <returns></returns>
+        public override int GetHashCode() => Integrity?.GetHashCode() ?? Src.GetHashCode();
+
+        public ManagerScriptDefinition(string src, string integrity = null, bool crossOriginUseCredentials = false, string type = "text/javascript")
+        {
+            if (src == null) throw new ArgumentNullException(nameof(src));
+            if (string.IsNullOrWhiteSpace(src)) throw new ArgumentException("Source url must not be null or whitespace.", nameof(src));
+            Src = src;
+            Integrity = integrity;
+            CrossOriginUseCredentials = crossOriginUseCredentials;
+            Type = type;
+        }
+
+        /// <summary>
+        /// WARNING: DO NOT USE THIS VALUE FOR INJECTING INTO A PAGE. IT IS NOT SANITIZED. IT SHOULD ONLY BE USED FOR TESTING OR DISPLAY PURPOSES ONLY.
+        /// Returns a text string of what a rendered script tag for this script would look like.
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString() => $"<script type=\"{Type}\" src=\"{Src}\"{(string.IsNullOrWhiteSpace(Integrity) ? "":$" integrity=\"{Integrity}\" crossorigin=\"{(CrossOriginUseCredentials ? "use-credentials":"anonymous")}\"")}></script>";
+
+        /// <summary>
+        /// Backwards compatibility for the original string list.
+        /// </summary>
+        /// <param name="src"></param>
+        public static implicit operator ManagerScriptDefinition(string src) => new ManagerScriptDefinition(src);
+
+        /// <summary>
+        /// Enables KVP-like list insertion.
+        /// </summary>
+        /// <param name="valTup"></param>
+        public static implicit operator ManagerScriptDefinition((string src, string integrity) valTup) => new ManagerScriptDefinition(valTup.src, valTup.integrity);
+    }
+}

--- a/core/Piranha.Manager/Module.cs
+++ b/core/Piranha.Manager/Module.cs
@@ -55,7 +55,7 @@ namespace Piranha.Manager
         /// <summary>
         /// The currently registered custom scripts.
         /// </summary>
-        public List<string> Scripts { get; private set; }
+        public List<ManagerScriptDefinition> Scripts { get; private set; }
 
         /// <summary>
         /// The currently registered custom styles.
@@ -133,7 +133,7 @@ namespace Piranha.Manager
         public Module()
         {
             Partials = new List<string>();
-            Scripts = new List<string>();
+            Scripts = new List<ManagerScriptDefinition>();
             Styles = new List<string>();
         }
 

--- a/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
+++ b/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
@@ -9,7 +9,7 @@ namespace Prianha.Manager.Tests
 {
     public class ManagerScriptingTests
     {
-        private ITestOutputHelper _helper;
+        private readonly ITestOutputHelper _helper;
 
         /// <summary>
         /// Test to both demonstrate how the class works and what each of its various forms translate to.
@@ -20,7 +20,6 @@ namespace Prianha.Manager.Tests
             var scriptDefs = new List<ManagerScriptDefinition>();
             scriptDefs.AddRange(new[]
             {
-                
                 "https://unpkg.com/jquery",
                 ("https://unpkg.com/react@16.7.0/umd/react.production.min.js","sha384-bDWFfmoLfqL0ZuPgUiUz3ekiv8NyiuJrrk1wGblri8Nut8UVD6mj7vXhjnenE9vy"),
                 new ManagerScriptDefinition("This doesn't check for valid Urls atm, just nulls/whitespace only.", type:"text/babel"),

--- a/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
+++ b/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
@@ -24,6 +24,7 @@ namespace Prianha.Manager.Tests
                 "https://unpkg.com/jquery",
                 ("https://unpkg.com/react@16.7.0/umd/react.production.min.js","sha384-bDWFfmoLfqL0ZuPgUiUz3ekiv8NyiuJrrk1wGblri8Nut8UVD6mj7vXhjnenE9vy"),
                 new ManagerScriptDefinition("This doesn't check for valid Urls atm, just nulls/whitespace only.", type:"text/babel"),
+                new ManagerScriptDefinition("AGH", "HASHBROWNS",ECrossOriginPolicy.None),
                 "/lib/js/dist/somescript.min.js"
             });
 
@@ -32,6 +33,7 @@ namespace Prianha.Manager.Tests
                 "<script type=\"text/javascript\" src=\"https://unpkg.com/jquery\"></script>",
                 "<script type=\"text/javascript\" src=\"https://unpkg.com/react@16.7.0/umd/react.production.min.js\" integrity=\"sha384-bDWFfmoLfqL0ZuPgUiUz3ekiv8NyiuJrrk1wGblri8Nut8UVD6mj7vXhjnenE9vy\" crossorigin=\"anonymous\"></script>",
                 "<script type=\"text/babel\" src=\"This doesn't check for valid Urls atm, just nulls/whitespace only.\"></script>",
+                "<script type=\"text/javascript\" src=\"AGH\" integrity=\"HASHBROWNS\" ></script>",
                 "<script type=\"text/javascript\" src=\"/lib/js/dist/somescript.min.js\"></script>"
             };
             foreach (var scriptDef in scriptDefs)

--- a/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
+++ b/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Piranha.Manager;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Prianha.Manager.Tests
+{
+    public class ManagerScriptingTests
+    {
+        private ITestOutputHelper _helper;
+
+        /// <summary>
+        /// Test to both demonstrate how the class works and what each of its various forms translate to.
+        /// </summary>
+        [Fact]
+        public void CustomScriptListTest()
+        {
+            var scriptDefs = new List<ManagerScriptDefinition>();
+            scriptDefs.AddRange(new ManagerScriptDefinition[]
+            {
+                
+                "https://unpkg.com/jquery",
+                ("https://unpkg.com/react@16.7.0/umd/react.production.min.js","sha384-bDWFfmoLfqL0ZuPgUiUz3ekiv8NyiuJrrk1wGblri8Nut8UVD6mj7vXhjnenE9vy"),
+                new ManagerScriptDefinition("This doesn't check for valid Urls atm, just nulls/whitespace only.", type:"text/babel"),
+                "/lib/js/dist/somescript.min.js"
+            });
+
+            var outputs = new[]
+            {
+                "<script type=\"text/javascript\" src=\"https://unpkg.com/jquery\"></script>",
+                "<script type=\"text/javascript\" src=\"https://unpkg.com/react@16.7.0/umd/react.production.min.js\" integrity=\"sha384-bDWFfmoLfqL0ZuPgUiUz3ekiv8NyiuJrrk1wGblri8Nut8UVD6mj7vXhjnenE9vy\" crossorigin=\"anonymous\"></script>",
+                "<script type=\"text/babel\" src=\"This doesn't check for valid Urls atm, just nulls/whitespace only.\"></script>",
+                "<script type=\"text/javascript\" src=\"/lib/js/dist/somescript.min.js\"></script>"
+            };
+            foreach (var scriptDef in scriptDefs)
+            {
+                _helper.WriteLine(scriptDef.ToString());
+            }
+            Assert.Equal(scriptDefs.Select(c => c.ToString()), outputs);
+
+            Assert.Throws<ArgumentNullException>(() => new ManagerScriptDefinition(null));
+            Assert.Throws<ArgumentException>(() => new ManagerScriptDefinition(""));
+        }
+
+        public ManagerScriptingTests(ITestOutputHelper helper)
+        {
+            _helper = helper;
+        }
+    }
+}

--- a/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
+++ b/test/Prianha.Manager.Tests/ManagerScriptingTests.cs
@@ -18,7 +18,7 @@ namespace Prianha.Manager.Tests
         public void CustomScriptListTest()
         {
             var scriptDefs = new List<ManagerScriptDefinition>();
-            scriptDefs.AddRange(new ManagerScriptDefinition[]
+            scriptDefs.AddRange(new[]
             {
                 
                 "https://unpkg.com/jquery",

--- a/test/Prianha.Manager.Tests/Prianha.Manager.Tests.csproj
+++ b/test/Prianha.Manager.Tests/Prianha.Manager.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\core\Piranha.Manager\Piranha.Manager.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
# Summary

Adds a simple class that allows adding a hash alongside script tags and customizing the contents of the script tags. This allows SRI implementation in case a remote script is compromised by an attacker. This update also allowed different script types to be specified, and the crossorigin value can be specified.

The class auto-converts from string by specifying the single string as the value of src, so all modules that rely on injecting custom script files into the manager will not break from upgrading to this class.

# Rationale

Many scripts nowadays are distributed via CDN. However, [as past events have shown](https://portswigger.net/daily-swig/cdn-flaw-left-thousands-of-websites-open-to-abuse), for all their benefits, these sites can be targeted by attacks and become new attack surfaces for the sake of better loading speed. By adding SRI support, custom manager scripts can be loaded from a CDN without having to worry about the security concerns of doing so.


I'm not sure if this should merge into master but I'm pretty sure it doesn't belong in any of the other branches.

Note: this is a resubmit of a previous pull request with some fixes requested by the code checks applied (because I didn't realize it updates automatically when I push a new commit, sorry).