### PR TITLE
Updated the ImageBlock and ImageGalleryBlock to include the alt and title tags that have been added to the new media selector

### DIFF
--- a/examples/MvcWeb/Views/Cms/DisplayTemplates/ImageBlock.cshtml
+++ b/examples/MvcWeb/Views/Cms/DisplayTemplates/ImageBlock.cshtml
@@ -1,5 +1,5 @@
 @model Piranha.Extend.Blocks.ImageBlock
 
 <div class="block image-block">
-    <img src="@Url.Content(Model.Body)">
+    <img src="@Url.Content(Model.Body)" alt="@Model.Body.Media.AltText" title="@Model.Body.Media.Title">
 </div>

--- a/examples/MvcWeb/Views/Cms/DisplayTemplates/ImageGalleryBlock.cshtml
+++ b/examples/MvcWeb/Views/Cms/DisplayTemplates/ImageGalleryBlock.cshtml
@@ -15,7 +15,10 @@
         @foreach (var item in Model.Items)
         {
             <div class="carousel-item @(item == Model.Items.First() ? "active" : "")">
-                <img src="@Url.Content(WebApp.Media.ResizeImage(((ImageBlock)item).Body.Media, 890, 482))" class="d-block w-100">
+                @{
+                    var image = ((ImageBlock) item).Body.Media;
+                }
+                <img src="@Url.Content(WebApp.Media.ResizeImage(image, 890, 482))" class="d-block w-100" alt="@image.AltText" title="@image.Title">
             </div>
         }
     </div>

--- a/examples/RazorWeb/Pages/DisplayTemplates/ImageBlock.cshtml
+++ b/examples/RazorWeb/Pages/DisplayTemplates/ImageBlock.cshtml
@@ -1,5 +1,5 @@
 @model Piranha.Extend.Blocks.ImageBlock
 
 <div class="block image-block">
-    <img src="@Url.Content(Model.Body)">
+    <img src="@Url.Content(Model.Body)" alt="@Model.Body.Media.AltText" title="@Model.Body.Media.Title">
 </div>

--- a/examples/RazorWeb/Pages/DisplayTemplates/ImageGalleryBlock.cshtml
+++ b/examples/RazorWeb/Pages/DisplayTemplates/ImageGalleryBlock.cshtml
@@ -15,7 +15,10 @@
         @foreach (var item in Model.Items)
         {
             <div class="carousel-item @(item == Model.Items.First() ? "active" : "")">
-                <img src="@Url.Content(WebApp.Media.ResizeImage(((ImageBlock)item).Body.Media, 890, 482))" class="d-block w-100">
+                @{
+                    var image = ((ImageBlock) item).Body.Media;
+                }
+                <img src="@Url.Content(WebApp.Media.ResizeImage(image, 890, 482))" class="d-block w-100" alt="@image.AltText" title="@image.Title">
             </div>
         }
     </div>


### PR DESCRIPTION
Updated the ImageBlock and ImageGalleryBlock display templates so that they now include the "alt" and "title" text. This text comes from the media picker meta information.