### PR TITLE
Include XML documentation in the NuGet packages.

### DIFF
--- a/Piranha.sln
+++ b/Piranha.sln
@@ -37,9 +37,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuspec", ".nuspec", "{A1B6
 		nuspec\Piranha.AttributeBuilder.nuspec = nuspec\Piranha.AttributeBuilder.nuspec
 		nuspec\Piranha.Azure.BlobStorage.nuspec = nuspec\Piranha.Azure.BlobStorage.nuspec
 		nuspec\Piranha.Data.EF.nuspec = nuspec\Piranha.Data.EF.nuspec
+		nuspec\Piranha.Data.EF.PostgreSql.nuspec = nuspec\Piranha.Data.EF.PostgreSql.nuspec
 		nuspec\Piranha.Extensions.Sync.nuspec = nuspec\Piranha.Extensions.Sync.nuspec
 		nuspec\Piranha.ImageSharp.nuspec = nuspec\Piranha.ImageSharp.nuspec
 		nuspec\Piranha.Local.FileStorage.nuspec = nuspec\Piranha.Local.FileStorage.nuspec
+		nuspec\Piranha.Manager.Localization.nuspec = nuspec\Piranha.Manager.Localization.nuspec
 		nuspec\Piranha.Manager.nuspec = nuspec\Piranha.Manager.nuspec
 		nuspec\Piranha.nuspec = nuspec\Piranha.nuspec
 		nuspec\Piranha.Data.EF.MySql.nuspec = nuspec\Piranha.Data.EF.MySql.nuspec
@@ -47,6 +49,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuspec", ".nuspec", "{A1B6
 		nuspec\Piranha.Data.EF.SQLServer.nuspec = nuspec\Piranha.Data.EF.SQLServer.nuspec
 		nuspec\Piranha.Manager.Summernote.nuspec = nuspec\Piranha.Manager.Summernote.nuspec
 		nuspec\Piranha.Manager.TinyMCE.nuspec = nuspec\Piranha.Manager.TinyMCE.nuspec
+		nuspec\Piranha.WebApi.nuspec = nuspec\Piranha.WebApi.nuspec
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Piranha.AspNetCore.SimpleSecurity", "core\Piranha.AspNetCore.SimpleSecurity\Piranha.AspNetCore.SimpleSecurity.csproj", "{DAE71F77-F4C7-4727-83D3-3AFC7362886D}"

--- a/core/Piranha.AspNetCore.Identity.SQLServer/Piranha.AspNetCore.Identity.SQLServer.csproj
+++ b/core/Piranha.AspNetCore.Identity.SQLServer/Piranha.AspNetCore.Identity.SQLServer.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.AspNetCore.Identity.SQLite/Piranha.AspNetCore.Identity.SQLite.csproj
+++ b/core/Piranha.AspNetCore.Identity.SQLite/Piranha.AspNetCore.Identity.SQLite.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.AspNetCore.Identity/Piranha.AspNetCore.Identity.csproj
+++ b/core/Piranha.AspNetCore.Identity/Piranha.AspNetCore.Identity.csproj
@@ -5,6 +5,8 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.AspNetCore.SimpleSecurity/Piranha.AspNetCore.SimpleSecurity.csproj
+++ b/core/Piranha.AspNetCore.SimpleSecurity/Piranha.AspNetCore.SimpleSecurity.csproj
@@ -5,6 +5,8 @@
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
     <RootNamespace>Piranha.AspNetCore</RootNamespace>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.AspNetCore/Piranha.AspNetCore.csproj
+++ b/core/Piranha.AspNetCore/Piranha.AspNetCore.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.AttributeBuilder/Piranha.AttributeBuilder.csproj
+++ b/core/Piranha.AttributeBuilder/Piranha.AttributeBuilder.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Azure.BlobStorage/Piranha.Azure.BlobStorage.csproj
+++ b/core/Piranha.Azure.BlobStorage/Piranha.Azure.BlobStorage.csproj
@@ -5,6 +5,8 @@
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
     <RootNamespace>Piranha.Azure</RootNamespace>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Azure.Search/Piranha.Azure.Search.csproj
+++ b/core/Piranha.Azure.Search/Piranha.Azure.Search.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Extensions.Sync/Piranha.Extensions.Sync.csproj
+++ b/core/Piranha.Extensions.Sync/Piranha.Extensions.Sync.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.ImageSharp/Piranha.ImageSharp.csproj
+++ b/core/Piranha.ImageSharp/Piranha.ImageSharp.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.0-rc1</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Local.FileStorage/Piranha.Local.FileStorage.csproj
+++ b/core/Piranha.Local.FileStorage/Piranha.Local.FileStorage.csproj
@@ -3,6 +3,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Piranha\Piranha.csproj" />

--- a/core/Piranha.Manager.Core/Piranha.Manager.Core.csproj
+++ b/core/Piranha.Manager.Core/Piranha.Manager.Core.csproj
@@ -5,6 +5,8 @@
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
     <RootNamespace>Piranha.Manager</RootNamespace>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Manager.Localization/Piranha.Manager.Localization.csproj
+++ b/core/Piranha.Manager.Localization/Piranha.Manager.Localization.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.1</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Manager.Summernote/Piranha.Manager.Summernote.csproj
+++ b/core/Piranha.Manager.Summernote/Piranha.Manager.Summernote.csproj
@@ -5,6 +5,8 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Manager.TinyMCE/Piranha.Manager.TinyMCE.csproj
+++ b/core/Piranha.Manager.TinyMCE/Piranha.Manager.TinyMCE.csproj
@@ -5,6 +5,8 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.Manager/Piranha.Manager.csproj
+++ b/core/Piranha.Manager/Piranha.Manager.csproj
@@ -5,6 +5,8 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha.WebApi/Piranha.WebApi.csproj
+++ b/core/Piranha.WebApi/Piranha.WebApi.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/Piranha/Piranha.csproj
+++ b/core/Piranha/Piranha.csproj
@@ -4,6 +4,8 @@
     <Version>8.1.0</Version>
     <Company>Piranha CMS</Company>
     <AssemblyTitle>Piranha</AssemblyTitle>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />

--- a/data/Piranha.Data.EF.MySql/Piranha.Data.EF.MySql.csproj
+++ b/data/Piranha.Data.EF.MySql/Piranha.Data.EF.MySql.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.2</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/data/Piranha.Data.EF.PostgreSql/Piranha.Data.EF.PostgreSql.csproj
+++ b/data/Piranha.Data.EF.PostgreSql/Piranha.Data.EF.PostgreSql.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.2</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/data/Piranha.Data.EF.SQLServer/Piranha.Data.EF.SQLServer.csproj
+++ b/data/Piranha.Data.EF.SQLServer/Piranha.Data.EF.SQLServer.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.2</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/data/Piranha.Data.EF.SQLite/Piranha.Data.EF.SQLite.csproj
+++ b/data/Piranha.Data.EF.SQLite/Piranha.Data.EF.SQLite.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.2</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/data/Piranha.Data.EF/Piranha.Data.EF.csproj
+++ b/data/Piranha.Data.EF/Piranha.Data.EF.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>8.1.2</Version>
     <Company>Piranha CMS</Company>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nuspec/Piranha.AspNetCore.Identity.SQLServer.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.SQLServer.nuspec
@@ -29,5 +29,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.AspNetCore.Identity.SQLServer\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLServer.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLServer.dll" />
+    <file src="..\core\Piranha.AspNetCore.Identity.SQLServer\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLServer.xml" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLServer.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.AspNetCore.Identity.SQLite.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.SQLite.nuspec
@@ -29,5 +29,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.AspNetCore.Identity.SQLite\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLite.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLite.dll" />
+    <file src="..\core\Piranha.AspNetCore.Identity.SQLite\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLite.xml" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.SQLite.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.AspNetCore.Identity.nuspec
+++ b/nuspec/Piranha.AspNetCore.Identity.nuspec
@@ -28,6 +28,7 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.AspNetCore.Identity\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.dll" />
+    <file src="..\core\Piranha.AspNetCore.Identity\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.xml" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.xml" />
     <file src="..\core\Piranha.AspNetCore.Identity\bin\Release\netcoreapp3.1\Piranha.AspNetCore.Identity.Views.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.Identity.Views.dll" />
   </files>
 </package>

--- a/nuspec/Piranha.AspNetCore.SimpleSecurity.nuspec
+++ b/nuspec/Piranha.AspNetCore.SimpleSecurity.nuspec
@@ -27,5 +27,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.AspNetCore.SimpleSecurity\bin\Release\netcoreapp3.1\Piranha.AspNetCore.SimpleSecurity.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.SimpleSecurity.dll" />
+    <file src="..\core\Piranha.AspNetCore.SimpleSecurity\bin\Release\netcoreapp3.1\Piranha.AspNetCore.SimpleSecurity.xml" target="lib\netcoreapp3.1\Piranha.AspNetCore.SimpleSecurity.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.AspNetCore.nuspec
+++ b/nuspec/Piranha.AspNetCore.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.AspNetCore\bin\Release\netcoreapp3.1\Piranha.AspNetCore.dll" target="lib\netcoreapp3.1\Piranha.AspNetCore.dll" />
+    <file src="..\core\Piranha.AspNetCore\bin\Release\netcoreapp3.1\Piranha.AspNetCore.xml" target="lib\netcoreapp3.1\Piranha.AspNetCore.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.AttributeBuilder.nuspec
+++ b/nuspec/Piranha.AttributeBuilder.nuspec
@@ -26,5 +26,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.AttributeBuilder\bin\Release\netstandard2.0\Piranha.AttributeBuilder.dll" target="lib\netstandard2.0\Piranha.AttributeBuilder.dll" />
+    <file src="..\core\Piranha.AttributeBuilder\bin\Release\netstandard2.0\Piranha.AttributeBuilder.xml" target="lib\netstandard2.0\Piranha.AttributeBuilder.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Azure.BlobStorage.nuspec
+++ b/nuspec/Piranha.Azure.BlobStorage.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Azure.BlobStorage\bin\Release\netstandard2.0\Piranha.Azure.BlobStorage.dll" target="lib\netstandard2.0\Piranha.Azure.BlobStorage.dll" />
+    <file src="..\core\Piranha.Azure.BlobStorage\bin\Release\netstandard2.0\Piranha.Azure.BlobStorage.xml" target="lib\netstandard2.0\Piranha.Azure.BlobStorage.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Data.EF.MySql.nuspec
+++ b/nuspec/Piranha.Data.EF.MySql.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\data\Piranha.Data.EF.MySql\bin\Release\netstandard2.0\Piranha.Data.EF.MySql.dll" target="lib\netstandard2.0\Piranha.Data.EF.MySql.dll" />
+    <file src="..\data\Piranha.Data.EF.MySql\bin\Release\netstandard2.0\Piranha.Data.EF.MySql.xml" target="lib\netstandard2.0\Piranha.Data.EF.MySql.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Data.EF.PostgreSql.nuspec
+++ b/nuspec/Piranha.Data.EF.PostgreSql.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\data\Piranha.Data.EF.PostgreSql\bin\Release\netstandard2.0\Piranha.Data.EF.PostgreSql.dll" target="lib\netstandard2.0\Piranha.Data.EF.PostgreSql.dll" />
+    <file src="..\data\Piranha.Data.EF.PostgreSql\bin\Release\netstandard2.0\Piranha.Data.EF.PostgreSql.xml" target="lib\netstandard2.0\Piranha.Data.EF.PostgreSql.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Data.EF.SQLServer.nuspec
+++ b/nuspec/Piranha.Data.EF.SQLServer.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\data\Piranha.Data.EF.SQLServer\bin\Release\netstandard2.0\Piranha.Data.EF.SQLServer.dll" target="lib\netstandard2.0\Piranha.Data.EF.SQLServer.dll" />
+    <file src="..\data\Piranha.Data.EF.SQLServer\bin\Release\netstandard2.0\Piranha.Data.EF.SQLServer.xml" target="lib\netstandard2.0\Piranha.Data.EF.SQLServer.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Data.EF.SQLite.nuspec
+++ b/nuspec/Piranha.Data.EF.SQLite.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\data\Piranha.Data.EF.SQLite\bin\Release\netstandard2.0\Piranha.Data.EF.SQLite.dll" target="lib\netstandard2.0\Piranha.Data.EF.SQLite.dll" />
+    <file src="..\data\Piranha.Data.EF.SQLite\bin\Release\netstandard2.0\Piranha.Data.EF.SQLite.xml" target="lib\netstandard2.0\Piranha.Data.EF.SQLite.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Data.EF.nuspec
+++ b/nuspec/Piranha.Data.EF.nuspec
@@ -28,5 +28,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\data\Piranha.Data.EF\bin\Release\netstandard2.0\Piranha.Data.EF.dll" target="lib\netstandard2.0\Piranha.Data.EF.dll" />
+    <file src="..\data\Piranha.Data.EF\bin\Release\netstandard2.0\Piranha.Data.EF.xml" target="lib\netstandard2.0\Piranha.Data.EF.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Extensions.Sync.nuspec
+++ b/nuspec/Piranha.Extensions.Sync.nuspec
@@ -26,5 +26,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Extensions.Sync\bin\Release\netstandard2.0\Piranha.Extensions.Sync.dll" target="lib\netstandard2.0\Piranha.Extensions.Sync.dll" />
+    <file src="..\core\Piranha.Extensions.Sync\bin\Release\netstandard2.0\Piranha.Extensions.Sync.xml" target="lib\netstandard2.0\Piranha.Extensions.Sync.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.ImageSharp.nuspec
+++ b/nuspec/Piranha.ImageSharp.nuspec
@@ -27,5 +27,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.ImageSharp\bin\Release\netstandard2.0\Piranha.ImageSharp.dll" target="lib\netstandard2.0\Piranha.ImageSharp.dll" />
+    <file src="..\core\Piranha.ImageSharp\bin\Release\netstandard2.0\Piranha.ImageSharp.xml" target="lib\netstandard2.0\Piranha.ImageSharp.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Local.FileStorage.nuspec
+++ b/nuspec/Piranha.Local.FileStorage.nuspec
@@ -26,5 +26,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Local.FileStorage\bin\Release\netstandard2.0\Piranha.Local.FileStorage.dll" target="lib\netstandard2.0\Piranha.Local.FileStorage.dll" />
+    <file src="..\core\Piranha.Local.FileStorage\bin\Release\netstandard2.0\Piranha.Local.FileStorage.xml" target="lib\netstandard2.0\Piranha.Local.FileStorage.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Manager.Localization.nuspec
+++ b/nuspec/Piranha.Manager.Localization.nuspec
@@ -26,6 +26,7 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Manager.Localization\bin\Release\netstandard2.0\Piranha.Manager.Localization.dll" target="lib\netstandard2.0\Piranha.Manager.Localization.dll" />
+    <file src="..\core\Piranha.Manager.Localization\bin\Release\netstandard2.0\Piranha.Manager.Localization.xml" target="lib\netstandard2.0\Piranha.Manager.Localization.xml" />
     <file src="..\core\Piranha.Manager.Localization\bin\Release\netstandard2.0\**\*.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/nuspec/Piranha.Manager.Summernote.nuspec
+++ b/nuspec/Piranha.Manager.Summernote.nuspec
@@ -26,6 +26,7 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Manager.Summernote\bin\Release\netcoreapp3.1\Piranha.Manager.Summernote.dll" target="lib\netcoreapp3.1\Piranha.Manager.Summernote.dll" />
+    <file src="..\core\Piranha.Manager.Summernote\bin\Release\netcoreapp3.1\Piranha.Manager.Summernote.xml" target="lib\netcoreapp3.1\Piranha.Manager.Summernote.xml" />
     <file src="..\core\Piranha.Manager.Summernote\bin\Release\netcoreapp3.1\Piranha.Manager.Summernote.views.dll" target="lib\netcoreapp3.1\Piranha.Manager.Summernote.views.dll" />
   </files>
 </package>

--- a/nuspec/Piranha.Manager.TinyMCE.nuspec
+++ b/nuspec/Piranha.Manager.TinyMCE.nuspec
@@ -26,5 +26,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Manager.TinyMCE\bin\Release\netcoreapp3.1\Piranha.Manager.TinyMCE.dll" target="lib\netcoreapp3.1\Piranha.Manager.TinyMCE.dll" />
+    <file src="..\core\Piranha.Manager.TinyMCE\bin\Release\netcoreapp3.1\Piranha.Manager.TinyMCE.xml" target="lib\netcoreapp3.1\Piranha.Manager.TinyMCE.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.Manager.nuspec
+++ b/nuspec/Piranha.Manager.nuspec
@@ -29,7 +29,9 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.Manager\bin\Release\netcoreapp3.1\Piranha.Manager.Core.dll" target="lib\netcoreapp3.1\Piranha.Manager.Core.dll" />
+    <file src="..\core\Piranha.Manager\bin\Release\netcoreapp3.1\Piranha.Manager.Core.xml" target="lib\netcoreapp3.1\Piranha.Manager.Core.xml" />
     <file src="..\core\Piranha.Manager\bin\Release\netcoreapp3.1\Piranha.Manager.dll" target="lib\netcoreapp3.1\Piranha.Manager.dll" />
+    <file src="..\core\Piranha.Manager\bin\Release\netcoreapp3.1\Piranha.Manager.xml" target="lib\netcoreapp3.1\Piranha.Manager.xml" />
     <file src="..\core\Piranha.Manager\bin\Release\netcoreapp3.1\Piranha.Manager.views.dll" target="lib\netcoreapp3.1\Piranha.Manager.views.dll" />
   </files>
 </package>

--- a/nuspec/Piranha.WebApi.nuspec
+++ b/nuspec/Piranha.WebApi.nuspec
@@ -26,5 +26,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha.WebApi\bin\Release\netcoreapp3.1\Piranha.WebApi.dll" target="lib\netcoreapp3.1\Piranha.WebApi.dll" />
+    <file src="..\core\Piranha.WebApi\bin\Release\netcoreapp3.1\Piranha.WebApi.xml" target="lib\netcoreapp3.1\Piranha.WebApi.xml" />
   </files>
 </package>

--- a/nuspec/Piranha.nuspec
+++ b/nuspec/Piranha.nuspec
@@ -31,5 +31,6 @@ https://github.com/piranhacms/piranha.core/wiki/changelog
   <files>
     <file src="piranha.png" target="images\" />
     <file src="..\core\Piranha\bin\Release\netstandard2.0\Piranha.dll" target="lib\netstandard2.0\Piranha.dll" />
+    <file src="..\core\Piranha\bin\Release\netstandard2.0\Piranha.xml" target="lib\netstandard2.0\Piranha.xml" />
   </files>
 </package>


### PR DESCRIPTION
This makes it possible for IDE's to show the short summaries when hovering over types or members.

Note: The `<NoWarn>$(NoWarn);1591</NoWarn>` is included in the project file to suppress warnings regarding missing documentation for publicly visible types and members.

There are however some invalid documentation as well, so this PR currently introduces a good number of warnings.
Some of these warnings are due to typos, such that a comment-tag is not properly closed.
Some of them are regarding (type) parameters that have missing documentation.
Some of them are regarding (type) parameters that do not exist, but have documentation.

The PR also adds three missing .nuspec files to the solution file.