### PR TITLE
Update to piranha/plugin.min.js

### DIFF
--- a/core/Piranha.Manager.TinyMCE/assets/tinymce/plugins/piranhalink/plugin.min.js
+++ b/core/Piranha.Manager.TinyMCE/assets/tinymce/plugins/piranhalink/plugin.min.js
@@ -42,12 +42,7 @@ tinymce.PluginManager.add('piranhalink', function (editor) {
             };
         }
 
-        var textCtrl;
-        if (isText) {
-            textCtrl = { name: 'text', type: 'input', label: 'Text to display' };
-        }
-
-        piranha.win = win = editor.windowManager.open({
+        var editorOptions = {
             title: "Insert/edit link",
             data: data,
             initialData: data,
@@ -70,7 +65,6 @@ tinymce.PluginManager.add('piranhalink', function (editor) {
                             }
                         ]
                     },
-                    textCtrl,
                     {
                         name: 'target',
                         type: 'selectbox',
@@ -84,15 +78,15 @@ tinymce.PluginManager.add('piranhalink', function (editor) {
             },
             buttons: [
                 {
-                  type: 'cancel',
-                  name: 'cancel',
-                  text: 'Cancel'
+                    type: 'cancel',
+                    name: 'cancel',
+                    text: 'Cancel'
                 },
                 {
-                  type: 'submit',
-                  name: 'save',
-                  text: 'Save',
-                  primary: true
+                    type: 'submit',
+                    name: 'save',
+                    text: 'Save',
+                    primary: true
                 }
             ],
             onSubmit: function (e) {
@@ -121,7 +115,12 @@ tinymce.PluginManager.add('piranhalink', function (editor) {
                     }, null);
                 }
             }
-        });
+        };
+
+        if (isText)
+            editorOptions.body.items.splice(1, 0, { name: 'text', type: 'input', label: 'Text to display' });
+
+        piranha.win = win = editor.windowManager.open(editorOptions);
     }
 
     var Utils = {


### PR DESCRIPTION
Prevents undefined "text" field from being added to the editor.windowManager when the content is not text. Fixes #965 