### PR TITLE
UseBlocks=false doesn't work with PostTypes

### DIFF
--- a/core/Piranha.Manager/assets/src/js/piranha.postedit.js
+++ b/core/Piranha.Manager/assets/src/js/piranha.postedit.js
@@ -117,6 +117,12 @@ piranha.postedit = new Vue({
                 else if (this.contentRegions.length > 0) {
                     this.selectedRegion = this.contentRegions[0].meta;
                 }
+            } else {
+                this.selectedRegion = {
+                    uid: "uid-blocks",
+                    name: null,
+                    icon: null,
+                };
             }
         },
         load: function (id) {


### PR DESCRIPTION
Although I do set this Attribute Property [PostType(Title="", UseBlocks=false)] to be false, the Manager allows for Block addition with Posts. this same problem doesn't exists with PageTypes.