### PR TITLE
Manager: Fix 404 when fetching empty-image.png from wrong path.

### DIFF
--- a/core/Piranha.Manager/Areas/Manager/Pages/ModuleList.cshtml
+++ b/core/Piranha.Manager/Areas/Manager/Pages/ModuleList.cshtml
@@ -43,7 +43,7 @@
                         <tbody>
                             <tr v-for="item in items">
                                 <td>
-                                    <img class="img-thumbnail img-thumbnail-sm" src="~/assets/img/empty-image.png" v-bind:src="item.iconUrl">
+                                    <img class="img-thumbnail img-thumbnail-sm" src="~/manager/assets/img/empty-image.png" v-bind:src="item.iconUrl">
                                 </td>
                                 <td class="align-middle">
                                     <h5>{{ item.name }}</h5>


### PR DESCRIPTION
When navigating to the Modules list in the manager empty-image.png is fetched if a module without an icon is listed.

However, this image is served from embedded resources in the manager module, which prefixes the path with ~/manager/assets.