### PR TITLE
Check for empty url when hosted in Virtual Directory

### DIFF
--- a/core/Piranha.AspNetCore/IntegratedMiddleware.cs
+++ b/core/Piranha.AspNetCore/IntegratedMiddleware.cs
@@ -50,7 +50,7 @@ namespace Piranha.AspNetCore
             if (!IsHandled(context) && !context.Request.Path.Value.StartsWith("/manager/assets/"))
             {
                 var url = context.Request.Path.HasValue ? context.Request.Path.Value : "";
-                var segments = url.Substring(1).Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                var segments = !string.IsNullOrEmpty(url) ? url.Substring(1).Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries) : new string[] { };
                 int pos = 0;
 
                 //


### PR DESCRIPTION
Fixes #1273 when hosted in a Virtual Directory.

I found this in version 8.3, but this PR is targeted against master.