### PR TITLE
Fix of issue #1338: ContentId not properly set

### DIFF
--- a/core/Piranha/Services/PageService.cs
+++ b/core/Piranha/Services/PageService.cs
@@ -727,7 +727,7 @@ namespace Piranha.Services
                     model.Created = DateTime.Now;
                 }
 
-                // Ensure conted id
+                // Ensure content id
                 if (model.ContentId == Guid.Empty)
                 {
                     model.ContentId = pageId;

--- a/core/Piranha/Services/PageService.cs
+++ b/core/Piranha/Services/PageService.cs
@@ -727,6 +727,12 @@ namespace Piranha.Services
                     model.Created = DateTime.Now;
                 }
 
+                // Ensure conted id
+                if (model.ContentId == Guid.Empty)
+                {
+                    model.ContentId = pageId;
+                }
+
                 // Validate model
                 var context = new ValidationContext(model);
                 Validator.ValidateObject(model, context, true);

--- a/core/Piranha/Services/PostService.cs
+++ b/core/Piranha/Services/PostService.cs
@@ -615,10 +615,17 @@ namespace Piranha.Services
                     model.Id = Guid.NewGuid();
                 }
 
+
                 // Ensure created date
                 if (model.Created == DateTime.MinValue)
                 {
                     model.Created = DateTime.Now;
+                }
+
+                // Ensure conted id
+                if (model.ContentId == Guid.Empty)
+                {
+                    model.ContentId = postId;
                 }
 
                 // Validate model

--- a/core/Piranha/Services/PostService.cs
+++ b/core/Piranha/Services/PostService.cs
@@ -615,14 +615,13 @@ namespace Piranha.Services
                     model.Id = Guid.NewGuid();
                 }
 
-
                 // Ensure created date
                 if (model.Created == DateTime.MinValue)
                 {
                     model.Created = DateTime.Now;
                 }
 
-                // Ensure conted id
+                // Ensure content id
                 if (model.ContentId == Guid.Empty)
                 {
                     model.ContentId = postId;


### PR DESCRIPTION
Assign comments a valid ContentId when saving the comment, for both services providing content that supports comments. Fixes issue #1338