### PR TITLE
remove unnecessary sitemap authroize permission attribute on sitemap …

### DIFF
--- a/core/Piranha.WebApi/SitemapApiController.cs
+++ b/core/Piranha.WebApi/SitemapApiController.cs
@@ -8,16 +8,15 @@
  *
  */
 
-using System;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Threading.Tasks;
 
 namespace Piranha.WebApi
 {
     [ApiController]
     [Route("api/sitemap")]
-    [Authorize(Policy = Permissions.Sitemap)]
     public class SitemapApiController : Controller
     {
         private readonly IApi _api;


### PR DESCRIPTION
…api controller

The check for the permission already exists in the action. Its better to remove the [Authorize] attribute on the controller because it prevents the if (!Module.AllowAnonymousAccess) check to work correctly by stopping the request from entering the action

[HttpGet]
        [Route("{id:Guid?}")]
        public async Task<IActionResult> GetById(Guid? id = null)
        {
            if (!Module.AllowAnonymousAccess)
            {
                if (!(await _auth.AuthorizeAsync(User, Permissions.Sitemap)).Succeeded)
                {
                    return Unauthorized();
                }
            }
            return Json(await _api.Sites.GetSitemapAsync(id));
        }