### PR TITLE
EF warning messages. Fixes issue 1490

### DIFF
--- a/data/Piranha.Data.EF/Repositories/MediaRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/MediaRepository.cs
@@ -81,9 +81,13 @@ namespace Piranha.Repositories
         /// </summary>
         /// <param name="ids">One or several media id</param>
         /// <returns>The matching media</returns>
-        public Task<IEnumerable<Models.Media>> GetById(params Guid[] ids) => _db.Media.AsNoTracking()
-            .Include(c => c.Versions).Where(m => ids.Contains(m.Id)).OrderBy(m => m.Filename).ToArrayAsync()
-            .ContinueWith(t => t.Result.Select(m => (Models.Media) m));
+        public Task<IEnumerable<Models.Media>> GetById(params Guid[] ids) => 
+            _db.Media.AsNoTracking()
+                .Include(c => c.Versions)
+                .Where(m => ids.Contains(m.Id))
+                .OrderBy(m => m.Filename)
+                .ToArrayAsync()
+                .ContinueWith(t => t.Result.Select(m => (Models.Media) m));
 
         /// <summary>
         /// Gets the media with the given id.

--- a/data/Piranha.Data.EF/Repositories/PageRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/PageRepository.cs
@@ -556,6 +556,9 @@ namespace Piranha.Repositories
                     pageQuery = pageQuery.AsNoTracking();
                 }
 
+                // FirstOrDefaultAsync(p => p.Id ...
+                pageQuery = pageQuery.OrderBy(p => p.Id);
+
                 var page = await pageQuery
                     .Include(p => p.Permissions)
                     .Include(p => p.Blocks).ThenInclude(b => b.Block).ThenInclude(b => b.Fields)
@@ -904,6 +907,9 @@ namespace Piranha.Repositories
             IQueryable<Page> query = _db.Pages
                 .AsNoTracking()
                 .Include(p => p.Permissions);
+
+            // FirstOrDefaultAsync(p => p.Id ...
+            query = query.OrderBy(p => p.Id);
 
             if (loadRelated)
             {

--- a/data/Piranha.Data.EF/Repositories/ParamRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/ParamRepository.cs
@@ -78,7 +78,8 @@ namespace Piranha.Repositories
         /// </summary>
         /// <param name="key">The unique key</param>
         /// <returns>The model</returns>
-        public Task<Param> GetByKey(string key) {
+        public Task<Param> GetByKey(string key)
+        {
             return _db.Params
                 .AsNoTracking()
                 .Select(p => new Param

--- a/data/Piranha.Data.EF/Repositories/PostRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/PostRepository.cs
@@ -701,6 +701,9 @@ namespace Piranha.Repositories
                     postQuery = postQuery.AsNoTracking();
                 }
 
+                // FirstOrDefaultAsync(p => p.Id ...
+                postQuery = postQuery.OrderBy(p => p.Id);
+
                 var post = await postQuery
                     .Include(p => p.Permissions)
                     .Include(p => p.Blocks).ThenInclude(b => b.Block).ThenInclude(b => b.Fields)
@@ -1044,6 +1047,9 @@ namespace Piranha.Repositories
                     .Include(p => p.Blocks).ThenInclude(b => b.Block).ThenInclude(b => b.Fields)
                     .Include(p => p.Fields);
             }
+
+            query = query.OrderBy(p => p.Created);
+
             return query.AsSplitQuery();
         }
 

--- a/examples/MvcWeb/Seed.cs
+++ b/examples/MvcWeb/Seed.cs
@@ -71,7 +71,7 @@ namespace MvcWeb
                 startpage.Hero.PrimaryImage = images[1].id;
                 startpage.Hero.Ingress =
                     "<p>A lightweight & unobtrusive CMS for ASP.NET Core.</p>" +
-                    "<p><small>Stable version 6.1.0 - 2019-05-01 - <a href=\"https://github.com/piranhacms/piranha.core/wiki/changelog\" target=\"_blank\">Changelog</a></small></p>";
+                    "<p><small>beta version 9.0.0 - 2021-01-28 - <a href=\"https://github.com/piranhacms/piranha.core/wiki/changelog\" target=\"_blank\">Changelog</a></small></p>";
 
                 // Teasers
                 startpage.Teasers.Add(new Models.Regions.Teaser


### PR DESCRIPTION
A couple of queries in `Piranha.EF.Data` are missing an `OrderBy` clause. I've used the sort key that most frequently follows as the search key in `FirstOrDefaultAsync`.
