### PR TITLE
Fix: Check for SitemapItem.MetaIndex

### DIFF
--- a/core/Piranha.AspNetCore/SitemapMiddleware.cs
+++ b/core/Piranha.AspNetCore/SitemapMiddleware.cs
@@ -102,7 +102,7 @@ namespace Piranha.AspNetCore
         {
             var urls = new List<Url>();
 
-            if (item.Published.HasValue && item.Published.Value <= DateTime.Now)
+            if (item.MetaIndex && item.Published.HasValue && item.Published.Value <= DateTime.Now)
             {
                 urls.Add(new Url
                 {


### PR DESCRIPTION
**Fixes**:

While `MetaIndex == true` is checked for posts

https://github.com/PiranhaCMS/piranha.core/blob/b4993907848d66c268f7b3154f64c377c21635ff/core/Piranha.AspNetCore/SitemapMiddleware.cs#L120-L122

this is not the case for pages

https://github.com/PiranhaCMS/piranha.core/blob/b4993907848d66c268f7b3154f64c377c21635ff/core/Piranha.AspNetCore/SitemapMiddleware.cs#L105-L107

Leads to pages becoming part of `sitemap.xml` which should not be included.