### PR TITLE
Fixed incorrect policy check on UserController.cs Delete

### DIFF
--- a/identity/Piranha.AspNetCore.Identity/Controllers/UserController.cs
+++ b/identity/Piranha.AspNetCore.Identity/Controllers/UserController.cs
@@ -199,7 +199,7 @@ namespace Piranha.AspNetCore.Identity.Controllers
         /// <param name="id">The user id</param>
         [HttpGet]
         [Route("/manager/user/delete/{id:Guid}")]
-        [Authorize(Policy = Permissions.UsersSave)]
+        [Authorize(Policy = Permissions.UsersDelete)]
         public async Task<IActionResult> Delete(Guid id)
         {
             var user = _db.Users.FirstOrDefault(u => u.Id == id);


### PR DESCRIPTION
Minor correction - the User delete policy checked the "UserSave" role instead of the "UserDelete" role.  Potentially leaving it open for someone to delete a user without having the "delete user" permission.