### PR TITLE
Updating to Pomelo.EntityFrameworkCore.MySql v5.0.0

### DIFF
--- a/data/Piranha.Data.EF.MySql/DbFactory.cs
+++ b/data/Piranha.Data.EF.MySql/DbFactory.cs
@@ -28,8 +28,10 @@ namespace Piranha.Data.EF.MySql
         /// <returns>The db context</returns>
         public MySqlDb CreateDbContext(string[] args)
         {
+            var connectionString = "server=localhost;port=3306;database=piranha;uid=root;password=password";
+
             var builder = new DbContextOptionsBuilder<MySqlDb>();
-            builder.UseMySql("Server=localhost;Port=8889;Database=piranha;User=root;Password=root;");
+            builder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
             return new MySqlDb(builder.Options);
         }
     }

--- a/data/Piranha.Data.EF.MySql/Piranha.Data.EF.MySql.csproj
+++ b/data/Piranha.Data.EF.MySql/Piranha.Data.EF.MySql.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0" />
     <ProjectReference Include="..\Piranha.Data.EF\Piranha.Data.EF.csproj" />
     <ProjectReference Include="..\..\core\Piranha\Piranha.csproj" />
   </ItemGroup>

--- a/identity/Piranha.AspNetCore.Identity.MySQL/DbFactory.cs
+++ b/identity/Piranha.AspNetCore.Identity.MySQL/DbFactory.cs
@@ -1,4 +1,5 @@
 ﻿#if DEBUG
+using System.Data;
 /*
  * Copyright (c) 2019 aatmmr
  *
@@ -28,8 +29,10 @@ namespace Piranha.AspNetCore.Identity.MySQL
         /// <returns>The db context</returns>
         public IdentityMySQLDb CreateDbContext(string[] args) 
         {
+            var connectionString = "server=localhost;port=3306;database=piranha;uid=root;password=password";
+
             var builder = new DbContextOptionsBuilder<IdentityMySQLDb>();
-            builder.UseMySql("server=localhost;port=3306;database=piranha;uid=root;password=password");
+            builder.UseMySql(connectionString, ServerVersion.AutoDetect(connectionString));
             return new IdentityMySQLDb(builder.Options);
         }
     }

--- a/identity/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
+++ b/identity/Piranha.AspNetCore.Identity.MySQL/Piranha.AspNetCore.Identity.MySQL.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0-alpha.1" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0" />
     <ProjectReference Include="..\Piranha.AspNetCore.Identity\Piranha.AspNetCore.Identity.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
**Changes:**

- Updates MySQL references in `Data`  and `Identity` to `Pomelo.EntityFrameworkCore.MySql` version `5.0.0`
- Updates `DBFactory` to include required `ServerVersion`. The implementation uses the automatic detection of the server version based of the given connection string.