### PR TITLE
Added n to Interal so it is now Internal

### DIFF
--- a/test/Piranha.Tests/Utils/InternalId.cs
+++ b/test/Piranha.Tests/Utils/InternalId.cs
@@ -14,9 +14,10 @@ namespace Piranha.Tests.Utils
 {
     public class InternalId
     {
+        //corrected to GenerateInternalId
         [Fact]
         public void ToTitleCase() {
-            Assert.Equal("MyTestValue", Piranha.Utils.GenerateInteralId("mY test vAlUE"));
+            Assert.Equal("MyTestValue", Piranha.Utils.GenerateInternalId("mY test vAlUE"));
         }
     }
 }


### PR DESCRIPTION
 // build fails 
Assert.Equal("MyTestValue", Piranha.Utils.GenerateInteralId("mY test vAlUE")); 
changed to  Assert.Equal("MyTestValue", Piranha.Utils.GenerateInternalId("mY test vAlUE"));