### PR TITLE
Cache level and minutes headers added to response

### DIFF
--- a/core/Piranha.AspNetCore/PiranhaMiddleware.cs
+++ b/core/Piranha.AspNetCore/PiranhaMiddleware.cs
@@ -472,6 +472,8 @@ namespace Piranha.AspNetCore
         public bool HandleCache(HttpContext context, Site site, RoutedContentBase content, int expires)
         {
             var headers = context.Response.GetTypedHeaders();
+            headers.Append("piranha-cache-level", Enum.GetName(App.CacheLevel));
+            headers.Append("piranha-cache-minutes", expires);
 
             if (expires > 0 && content.Published.HasValue)
             {


### PR DESCRIPTION
This will return the cache level Piranha is using as well as the number of minutes until cache expires. This is helpful for those running on multiple instances especially if teams are working on Piranha together. There is not always a consistent response and the no-cache headers are deceiving, so adding these specific headers is informative and leads people to the solution to a somewhat common problem.