### PR TITLE
Fixes model name error if validation error occurs.

### DIFF
--- a/core/Piranha.Manager/Controllers/MediaApiController.cs
+++ b/core/Piranha.Manager/Controllers/MediaApiController.cs
@@ -143,7 +143,7 @@ namespace Piranha.Manager.Controllers
             }
             catch (ValidationException e)
             {
-                var result = new AliasListModel();
+                var result = new MediaListModel();
                 result.Status = new StatusMessage
                 {
                     Type = StatusMessage.Error,


### PR DESCRIPTION
It should be MediaListModel instead of AliasListModel.