### PR TITLE
Fixed EmailConfirmed changing to false when user edit, see #1708

### DIFF
--- a/identity/Piranha.AspNetCore.Identity/Models/UserEditModel.cs
+++ b/identity/Piranha.AspNetCore.Identity/Models/UserEditModel.cs
@@ -85,10 +85,13 @@ namespace Piranha.AspNetCore.Identity.Models
                     return result;
                 }
 
-                result = await userManager.SetEmailAsync(user, User.Email);
-                if (!result.Succeeded)
+                if (await userManager.GetEmailAsync(user) != User.Email)
                 {
-                    return result;
+                    result = await userManager.SetEmailAsync(user, User.Email);
+                    if (!result.Succeeded)
+                    {
+                        return result;
+                    }
                 }
             }
 


### PR DESCRIPTION
UserManager in Microsoft.AspNetCore.Identity automatically sets EmailConfirmed to _false_ when calling **SetEmailAsync**, it should only be called when the email has changed. 

_Could use **ChangeEmailAsync** in the future if email confirmation is implemented._