### PR TITLE
Hide delete button for SYSADMIN role deletion.

### DIFF
--- a/identity/Piranha.AspNetCore.Identity/Areas/Manager/Views/Role/List.cshtml
+++ b/identity/Piranha.AspNetCore.Identity/Areas/Manager/Views/Role/List.cshtml
@@ -51,14 +51,17 @@
                 </td>
                 <td class="text-center">@role.UserCount</td>
                 <td class="actions one">
-                    @if ((await Auth.AuthorizeAsync(User, Piranha.AspNetCore.Identity.Permissions.RolesDelete)).Succeeded)
+                    @if (role.NormalizedName != "SYSADMIN")
                     {
-                        <form method="post" action="~/manager/role/delete">
-                            <input type="hidden" name="id" value="@role.Id">
-                            <button class="danger">
-                                <span class="fas fa-trash"></span>
-                            </button>
-                        </form>
+                        @if ((await Auth.AuthorizeAsync(User, Piranha.AspNetCore.Identity.Permissions.RolesDelete)).Succeeded)
+                        {
+                            <form method="post" action="~/manager/role/delete">
+                                <input type="hidden" name="id" value="@role.Id">
+                                <button class="danger">
+                                    <span class="fas fa-trash"></span>
+                                </button>
+                            </form>
+                        }
                     }
                 </td>
             </tr>

--- a/identity/Piranha.AspNetCore.Identity/Models/RoleListModel.cs
+++ b/identity/Piranha.AspNetCore.Identity/Models/RoleListModel.cs
@@ -32,7 +32,8 @@ namespace Piranha.AspNetCore.Identity.Models
                     .Select(r => new ListItem
                     {
                         Id = r.Id,
-                        Name = r.Name
+                        Name = r.Name,
+                        NormalizedName = r.NormalizedName
                     }).ToList()
             };
 
@@ -41,6 +42,7 @@ namespace Piranha.AspNetCore.Identity.Models
                 role.UserCount = db.UserRoles
                     .Count(r => r.RoleId == role.Id);
             }
+
             return model;
         }
 
@@ -48,6 +50,7 @@ namespace Piranha.AspNetCore.Identity.Models
         {
             public Guid Id { get; set; }
             public string Name { get; set; }
+            public string NormalizedName { get; set; }
             public int UserCount { get; set; }
         }
     }


### PR DESCRIPTION
Because the SYSADMIN role designed as cannot be deleted.
Fixed #1786 

Signed-off-by: Success Go <successgdc@gmail.com>