### PR TITLE
Changing SQL Server DB Schema at runtime (#802)

### DIFF
--- a/data/Piranha.Data.EF/PiranhaEFDatabaseSchemaExtension.cs
+++ b/data/Piranha.Data.EF/PiranhaEFDatabaseSchemaExtension.cs
@@ -1,0 +1,74 @@
+﻿/*
+ * Copyright (c) .NET Foundation and Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core
+ *
+ */
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+/// <summary>
+/// A database context extension used to store a custom database schema. 
+/// The schema set will be used as the default schema in the database context that this extension is configured.
+/// Used by the <see cref="PiranhaEFExtensions.UseCustomDatabaseSchema(DbContextOptionsBuilder, string)"/> extension method.
+/// </summary>
+internal class PiranhaEFDatabaseSchemaExtension : IDbContextOptionsExtension
+{
+    public PiranhaEFDatabaseSchemaExtension(string schema) => SetSchema(schema);
+
+    /// <summary>
+    /// Sets the schema.
+    /// </summary>
+    /// <param name="schema">The schema to use.</param>
+    /// <exception cref="ArgumentException">When schema is null or an empty string.</exception>
+    public void SetSchema(string schema)
+    {
+        if (string.IsNullOrWhiteSpace(schema))
+        {
+            throw new ArgumentException("Schema must be a non-empty string", nameof(schema));
+        }
+        Schema = schema;
+    }
+
+    private PiranhaEFDarabaseSchemaExtensionInfo _info;
+
+    public DbContextOptionsExtensionInfo Info => _info ??= new PiranhaEFDarabaseSchemaExtensionInfo(this);
+
+    public string Schema { get; private set; }
+
+    public void ApplyServices(IServiceCollection services)
+    {
+    }
+
+    public void Validate(IDbContextOptions options)
+    {
+    }
+}
+
+/// <summary>
+/// The database schema extension info.
+/// Used by <see cref="PiranhaEFDatabaseSchemaExtension"/> extension.
+/// </summary>
+internal class PiranhaEFDarabaseSchemaExtensionInfo : DbContextOptionsExtensionInfo
+{
+    public PiranhaEFDarabaseSchemaExtensionInfo(IDbContextOptionsExtension extension) : base(extension)
+    {
+    }
+
+    public override bool IsDatabaseProvider { get; } = false;
+    public override string LogFragment { get; } = string.Empty;
+
+    public override int GetServiceProviderHashCode() => 0;
+
+    public override void PopulateDebugInfo(IDictionary<string, string> debugInfo)
+    {
+    }
+
+    public override bool ShouldUseSameServiceProvider(DbContextOptionsExtensionInfo other) => true;
+}

--- a/data/Piranha.Data.EF/PiranhaEFExtensions.cs
+++ b/data/Piranha.Data.EF/PiranhaEFExtensions.cs
@@ -9,11 +9,18 @@
  */
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Piranha;
 using Piranha.Repositories;
 using Piranha.Services;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 public static class PiranhaEFExtensions
 {
@@ -91,5 +98,29 @@ public static class PiranhaEFExtensions
         services.Add(new ServiceDescriptor(typeof(IDb), typeof(T), scope));
 
         return services;
+    }
+
+    /// <summary>
+    /// Adds a custom database schema that will be used by the database context being configured.
+    /// </summary>
+    /// <param name="builder">The database context options builder.</param>
+    /// <param name="schema">The database schema.</param>
+    /// <returns>A database context options builder.</returns>
+    /// <exception cref="ArgumentException">Throws when <paramref name="schema"/> is null or empty.</exception>
+    public static DbContextOptionsBuilder UseCustomDatabaseSchema(this DbContextOptionsBuilder builder, string schema)
+    {
+        var extension = builder.Options.FindExtension<PiranhaEFDatabaseSchemaExtension>();
+        if (extension == null)
+        {
+            extension = new PiranhaEFDatabaseSchemaExtension(schema);
+        }
+        else
+        {
+            extension.SetSchema(schema);
+        }
+
+        ((IDbContextOptionsBuilderInfrastructure)builder).AddOrUpdateExtension(extension);
+
+        return builder;
     }
 }


### PR DESCRIPTION
Adds the ability to change the EF database context schema at runtime.

This can be achieved when configuring entity framework at startup

This is an example of how to configure separate schemas for both core and identity database context

```csharp
options.UseEF<SQLServerDb>(db => db
    .UseSqlServer(connectionString)
    .UseCustomDatabaseSchema("not_dbo"));
options.UseIdentityWithSeed<IdentitySQLServerDb>(db => db
    .UseSqlServer(connectionString)
    .UseCustomDatabaseSchema("id"));
```

This feature works with any database provider that supports schemas.

This is not a complete solution since the design time schema changes were still not addressed (See discussion on piranha.core/issues/802).
