### PR TITLE
Introducing a two level distributed cache

### DIFF
--- a/core/Piranha/Cache/DistributedTwoLevelCache.cs
+++ b/core/Piranha/Cache/DistributedTwoLevelCache.cs
@@ -1,0 +1,211 @@
+﻿/*
+ * Copyright (c) .NET Foundation and Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * http://github.com/piranhacms/piranha
+ *
+ */
+
+using System;
+using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Newtonsoft.Json;
+
+namespace Piranha.Cache
+{
+    /// <summary>
+    /// Two level distributed cache. The first level is a per application memory cache.
+    /// The second level is the distributed cache
+    /// </summary>
+    public class DistributedTwoLevelCache : ICache
+    {
+        private readonly IMemoryCache _firstLevelCache;
+        private readonly IDistributedCache _secondLevelCache;
+
+        private readonly JsonSerializerSettings _jsonSettings;
+        private readonly bool _clone;
+        private string _cacheVersion;
+
+        public const string CACHE_VERSION = "piranha_cache_version";
+
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        /// <param name="firstLevelCache">First level memory cache</param>
+        /// <param name="secondLevelCache">Second level distributed cache</param>
+        public DistributedTwoLevelCache(IMemoryCache firstLevelCache, IDistributedCache secondLevelCache)
+        {
+            _firstLevelCache = firstLevelCache;
+            _secondLevelCache = secondLevelCache;
+            _jsonSettings = new JsonSerializerSettings
+            {
+                TypeNameHandling = TypeNameHandling.All
+            };
+        }
+
+        /// <summary>
+        /// Protected constructor
+        /// </summary>
+        /// <param name="firstLevelCache">First level memory cache</param>
+        /// <param name="secondLevelCache">Second level distributed cache</param>
+        /// <param name="clone"></param>
+        protected DistributedTwoLevelCache(IMemoryCache firstLevelCache, IDistributedCache secondLevelCache, bool clone) : this(firstLevelCache, secondLevelCache)
+        {
+            _clone = clone;
+        }
+
+        /// <summary>
+        /// Gets the model with the specified key from cache.
+        /// </summary>
+        /// <typeparam name="T">The model type</typeparam>
+        /// <param name="key">The unique key</param>
+        /// <returns>The cached model, null it wasn't found</returns>
+        public T Get<T>(string key)
+        {
+            //Check if the item exists in the first level cache
+            if (UseFirstLevelCache(key) && _firstLevelCache.TryGetValue<T>(key, out var obj))
+            {
+                if (!_clone)
+                {
+                    return obj;
+                }
+
+                if (obj != null)
+                {
+                    return Utils.DeepClone(obj);
+                }
+
+                return default(T);
+            }
+
+            //The item didn't exist in the first level
+            //cache. Check in the second level cache
+            var json = _secondLevelCache.GetString(key);
+
+            if (!string.IsNullOrEmpty(json))
+            {
+                var ret = JsonConvert.DeserializeObject<T>(json, _jsonSettings);
+
+                //Update first level cache
+                SetUseFirstLevelCache(key, ret);
+
+                return ret;
+            }
+
+            //No item was found in first or second level cache
+            //Set first level cache to default(null)
+            SetUseFirstLevelCache(key, default(T));
+
+            return default(T);
+        }
+
+        /// <summary>
+        /// Sets the given model in the cache.
+        /// </summary>
+        /// <typeparam name="T">The model type</typeparam>
+        /// <param name="key">The unique key</param>
+        /// <param name="value">The model</param>
+        public void Set<T>(string key, T value)
+        {
+            _secondLevelCache.SetString(key, JsonConvert.SerializeObject(value, _jsonSettings));
+
+            //Create a new cache version. This will "clear" the first
+            //level cache for all instances
+            CreateNewCacheVersion();
+
+            //Cache it in the first level cache
+            SetUseFirstLevelCache(key, value);
+        }
+
+        /// <summary>
+        /// Removes the model with the specified key from cache.
+        /// </summary>
+        /// <param name="key">The unique key</param>
+        public void Remove(string key)
+        {
+            _secondLevelCache.Remove(key);
+
+            //Create a new cache version. This will "clear" the first
+            //level cache for all instances
+            CreateNewCacheVersion();
+
+            SetUseFirstLevelCache(key, null);
+        }
+
+        /// <summary>
+        /// Invalidates first level cache
+        /// </summary>
+        public void InvalidateFirstLevelCache()
+        {
+            //Will cause that all first level cache items
+            //are invalid
+            _cacheVersion = null;
+        }
+
+        private string CacheVersion
+        {
+            get
+            {
+                //If cacheversion is null this is the first time we check it for this request
+                //Then we need to get the current version from the distributed cache
+                //If no current version exists in the distributed cache we need to create it
+                if (_cacheVersion == null)
+                {
+                    _cacheVersion = _secondLevelCache.GetString(CACHE_VERSION);
+                    if (_cacheVersion == null)
+                    {
+                        CreateNewCacheVersion();
+                    }
+                }
+                return _cacheVersion;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new cache version This will "clear" the first
+        /// level cache.
+        /// </summary>
+        private void CreateNewCacheVersion()
+        {
+            _cacheVersion = Guid.NewGuid().ToString("N");
+            _secondLevelCache.SetString(CACHE_VERSION, _cacheVersion);
+        }
+
+        /// <summary>
+        /// Checks if first level cache should be used
+        /// </summary>
+        /// <param name="key">key</param>
+        /// <returns></returns>
+        private bool UseFirstLevelCache(string key)
+        {
+            _firstLevelCache.TryGetValue<string>(GetFirstLevelCacheVersionKey(key), out var obj);
+            return obj != null && obj == "1";
+        }
+
+        /// <summary>
+        /// Sets that we should use the first level cache for the specified key
+        /// </summary>
+        /// <param name="key">key</param>
+        private void SetUseFirstLevelCache(string key, object obj)
+        {
+            _firstLevelCache.Set(key, obj, new MemoryCacheEntryOptions() );
+            _firstLevelCache.Set(GetFirstLevelCacheVersionKey(key), "1");
+        }
+
+        /// <summary>
+        /// Gets the first level cache key version
+        /// </summary>
+        /// <param name="key"></param>
+        /// <returns></returns>
+        private string GetFirstLevelCacheVersionKey(string key)
+        {
+            return key + "_" + CacheVersion;
+        }
+
+    }
+
+
+}

--- a/core/Piranha/Cache/DistributedTwoLevelCacheWithClone.cs
+++ b/core/Piranha/Cache/DistributedTwoLevelCacheWithClone.cs
@@ -1,0 +1,31 @@
+﻿/*
+ * Copyright (c) .NET Foundation and Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * http://github.com/piranhacms/piranha
+ *
+ */
+
+using System;
+using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Newtonsoft.Json;
+
+namespace Piranha.Cache
+{
+    /// <summary>
+    /// Two level distributed cache. The first level is a per application memory cache.
+    /// The second level is the distributed cache
+    /// </summary>
+    public class DistributedTwoLevelCacheWithClone : DistributedTwoLevelCache
+    {
+        protected DistributedTwoLevelCacheWithClone(IMemoryCache firstLevelCache, IDistributedCache secondLevelCache) : base(firstLevelCache, secondLevelCache, true)
+        {
+        }
+    }
+
+
+}

--- a/core/Piranha/Extensions/PiranhaDistributedCacheExtensions.cs
+++ b/core/Piranha/Extensions/PiranhaDistributedCacheExtensions.cs
@@ -11,6 +11,7 @@
 using System;
 using System.Linq;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
 using Piranha;
 using Piranha.Cache;
@@ -36,6 +37,33 @@ public static class PiranhaDistributedCacheExtensions
     }
 
     /// <summary>
+    /// Adds the distributed two level cache service for repository caching.
+    /// </summary>
+    /// <param name="services">The current service collection</param>
+    /// <param name="clone"></param>
+    /// <returns>The updated service collection</returns>
+    public static IServiceCollection AddPiranhaDistributedTwoLevelCache(this IServiceCollection services, bool clone = false)
+    {
+        // Check dependent services
+        if (!services.Any(s => s.ServiceType == typeof(IDistributedCache)))
+        {
+            throw new NotSupportedException("You need to register a IDistributedCache service in order to use distributed two level cache in Piranha");
+        }
+
+        // Check dependent services
+        if (!services.Any(s => s.ServiceType == typeof(IMemoryCache)))
+        {
+            throw new NotSupportedException("You need to register a IMemoryCache service in order to use distributed two level cache in Piranha");
+        }
+
+        if (clone)
+        {
+            return services.AddScoped<ICache, DistributedTwoLevelCacheWithClone>();
+        }
+        return services.AddScoped<ICache, DistributedTwoLevelCache>();
+    }
+
+    /// <summary>
     /// Uses the distributed cache service in the current application.
     /// </summary>
     /// <param name="serviceBuilder">The current service builder</param>
@@ -47,4 +75,18 @@ public static class PiranhaDistributedCacheExtensions
 
         return serviceBuilder;
     }
+
+    /// <summary>
+    /// Uses the distributed two level cache service in the current application.
+    /// </summary>
+    /// <param name="serviceBuilder">The current service builder</param>
+    /// <param name="clone">If returned objects should be cloned</param>
+    /// <returns>The updated service builder</returns>
+    public static PiranhaServiceBuilder UseDistributedTwoLevelCache(this PiranhaServiceBuilder serviceBuilder, bool clone = false)
+    {
+        serviceBuilder.Services.AddPiranhaDistributedTwoLevelCache(clone);
+
+        return serviceBuilder;
+    }
+
 }

--- a/test/Piranha.Tests/DistributedTwoLevelCache.cs
+++ b/test/Piranha.Tests/DistributedTwoLevelCache.cs
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) .NET Foundation and Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ *
+ * http://github.com/piranhacms/piranha
+ *
+ */
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Piranha.Tests
+{
+    public class DistributedTwoLevelCache
+    {
+
+        public DistributedTwoLevelCache() {
+        }
+
+        [Fact]
+        public void SingleInstanceGetSetRemove()
+        {
+            var firstLevelCache = new MemoryCacheMock();
+            var secondLevelCache = new DistributedCacheMock();
+            var distributedCache = new Cache.DistributedTwoLevelCache(firstLevelCache, secondLevelCache);
+
+            var key = "id";
+
+            //Set item for first time
+            //This will cause 2 hits on second level cache
+            distributedCache.Set(key, "ver");
+            Assert.Equal(2, secondLevelCache.Hits);
+
+            //Get item from cache. The first level
+            //cache will be used. No hits on the second level
+            //cache
+            Assert.Equal("ver", distributedCache.Get<string>(key));
+            Assert.Equal(2, secondLevelCache.Hits);
+
+            //Update the item
+            //This should cause 2 hits on the second level
+            //cache
+            distributedCache.Set(key, "ver2");
+            Assert.Equal(4, secondLevelCache.Hits);
+
+            //Get item from cache again once
+            //No second level cache hits
+            Assert.Equal("ver2", distributedCache.Get<string>(key));
+            Assert.Equal(4, secondLevelCache.Hits);
+
+            //Get item from cache again twice
+            //No second level cache hits
+            Assert.Equal("ver2", distributedCache.Get<string>(key));
+            Assert.Equal(4, secondLevelCache.Hits);
+
+            //Remove item
+            //This will cause 2 hits on second level cache
+            distributedCache.Remove(key);
+            Assert.Equal(6, secondLevelCache.Hits);
+
+            //Get removed item from cache
+            //No second level cache hits
+            Assert.Null(distributedCache.Get<string>(key));
+            Assert.Equal(6, secondLevelCache.Hits);
+
+        }
+
+        [Fact]
+        public void TwoInstanceGetSetRemove()
+        {
+            var secondLevelCache = new DistributedCacheMock();
+            var firstLevelCache1 = new MemoryCacheMock();
+            var firstLevelCache2 = new MemoryCacheMock();
+            var instance1 = new Cache.DistributedTwoLevelCache(firstLevelCache1, secondLevelCache);
+            var instance2 = new Cache.DistributedTwoLevelCache(firstLevelCache2, secondLevelCache);
+
+            //Test item key
+            var key = "id";
+
+            //Set item from instance 1
+            //2 hits on second level cache
+            instance1.Set(key, "ver");
+            Assert.Equal(2, secondLevelCache.Hits);
+
+            //Item should be in instance 1 first level cache
+            //No hits on second level cache
+            Assert.Equal("ver", instance1.Get<string>(key));
+            Assert.Equal(2, secondLevelCache.Hits);
+
+            //Item should be fetched into instance 2 first level
+            //cache
+            //2 hits on second level cache
+            Assert.Equal("ver", instance2.Get<string>(key));
+            Assert.Equal(4, secondLevelCache.Hits);
+
+            //Update item from instance 1
+            //2 hits on second level cache
+            instance1.Set(key, "ver2");
+            Assert.Equal(6, secondLevelCache.Hits);
+
+            //Instance 1 should have the correct item, because it set 
+            //the new item
+            //No hits on second level cache
+            Assert.Equal("ver2", instance1.Get<string>(key));
+            Assert.Equal(6, secondLevelCache.Hits);
+
+            //Instance 2 should not have the correct item yet, because
+            //the firstlevel cache has not been cleared. In a prod
+            //scenario the first level cache will check the cache version
+            //in the next request
+            //No hits on second level cache
+            Assert.Equal("ver", instance2.Get<string>(key));
+            Assert.Equal(6, secondLevelCache.Hits);
+
+            //But if we clear instance 2's first level cache it should
+            //get the new item
+            //2 hits on second level cache
+            instance2.InvalidateFirstLevelCache();
+            Assert.Equal("ver2", instance2.Get<string>(key));
+            Assert.Equal(8, secondLevelCache.Hits);
+
+            //Instance 1 removes the item
+            //2 hits on second level cache
+            instance1.Remove(key);
+            Assert.Equal(10, secondLevelCache.Hits);
+
+            //Instance 1 first level cache should have been updated
+            //No hits on second level cache
+            Assert.Null(instance1.Get<string>(key));
+            Assert.Equal(10, secondLevelCache.Hits);
+
+            //Instance 2 first level cache should not have 
+            //been updated. In a prod scenario the first level
+            //cache will check the cache version in the next request
+            //No hits on second level cache
+            Assert.NotNull(instance2.Get<string>(key));
+
+            //If we clear instance 2 first level cache the
+            //item should have been removed
+            //2 hits on second level cache
+            instance2.InvalidateFirstLevelCache();
+            Assert.Null(instance2.Get<string>(key));
+            Assert.Equal(12, secondLevelCache.Hits);
+        }
+
+        #region Mocks
+        private class DistributedCacheMock : IDistributedCache
+        {
+
+            public int Gets { get; set; } = 0;
+            public int Sets { get; set; } = 0;
+            public int Removes { get; set; } = 0;
+            public int Hits => Gets + Sets + Removes;
+            public readonly Dictionary<string, byte[]> Cache = new();
+
+            public byte[] Get(string key)
+            {
+                Gets++;
+                if (Cache.TryGetValue(key,  out byte[] data))
+                {
+                    return data;
+                }
+                return null;
+            }
+
+            public Task<byte[]> GetAsync(string key, CancellationToken token = new CancellationToken())
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+            {
+                Sets++;
+                Cache[key] = value;
+            }
+
+            public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options,
+                CancellationToken token = new CancellationToken())
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Refresh(string key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task RefreshAsync(string key, CancellationToken token = new CancellationToken())
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Remove(string key)
+            {
+                Removes++;
+                if (Cache.ContainsKey(key))
+                {
+                    Cache.Remove(key);
+                }
+            }
+
+            public Task RemoveAsync(string key, CancellationToken token = new CancellationToken())
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private class MemoryCacheMock : IMemoryCache
+        {
+            public IList<ICacheEntry> CacheEntries = new List<ICacheEntry>();
+            public int Gets { get; set; } = 0;
+            public int Sets { get; set; } = 0;
+            public int Removes { get; set; } = 0;
+            public int Total => Gets + Sets + Removes;
+
+            public MemoryCacheMock()
+            {
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public bool TryGetValue(object key, out object value)
+            {
+                Gets++;
+                var tmp = CacheEntries.SingleOrDefault(o => o.Key.ToString() == key.ToString());
+                if (tmp != null)
+                {
+                    value = tmp.Value;
+                    return true;
+                }
+
+                value = null;
+                return false;
+            }
+
+            public ICacheEntry CreateEntry(object key)
+            {
+                Sets++;
+                var tmp = CacheEntries.SingleOrDefault(o => o.Key.ToString() == key.ToString());
+
+                if (tmp == null)
+                {
+                    tmp = new CacheEntryMock()
+                    {
+                        Key = key
+                    };
+                    CacheEntries.Add(tmp);
+                }
+                
+                return tmp;
+            }
+
+            public void Remove(object key)
+            {
+                Removes++;
+                CacheEntries = CacheEntries.Where(o => o.Key.ToString() != key.ToString()).ToList();
+            }
+
+        }
+
+        private class CacheEntryMock : ICacheEntry
+        {
+            public void Dispose()
+            {
+            }
+
+            public object Key { get; set; }
+            public object Value { get; set; }
+            public DateTimeOffset? AbsoluteExpiration { get; set; }
+            public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+            public TimeSpan? SlidingExpiration { get; set; }
+            public IList<IChangeToken> ExpirationTokens { get; }
+            public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; }
+            public CacheItemPriority Priority { get; set; }
+            public long? Size { get; set; }
+        }
+
+        #endregion
+
+    }
+}

--- a/test/Piranha.Tests/Services/AliasTests.cs
+++ b/test/Piranha.Tests/Services/AliasTests.cs
@@ -38,6 +38,17 @@ namespace Piranha.Tests.Services
         }
     }
 
+
+    [Collection("Integration tests")]
+    public class AliasTestsDistributedTwoLevelCache : AliasTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
     [Collection("Integration tests")]
     public class AliasTests : BaseTestsAsync
     {
@@ -110,7 +121,9 @@ namespace Piranha.Tests.Services
             using (var api = CreateApi()) {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(AliasTestsMemoryCache) ||
-                    this.GetType() == typeof(AliasTestsDistributedCache));
+                    this.GetType() == typeof(AliasTestsDistributedCache) ||
+                    this.GetType() == typeof(AliasTestsDistributedTwoLevelCache) 
+                    );
             }
         }
 

--- a/test/Piranha.Tests/Services/CommentTests.cs
+++ b/test/Piranha.Tests/Services/CommentTests.cs
@@ -41,6 +41,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class CommentTestsDistributedTwoLevelCache : CommentTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class CommentTests : BaseTestsAsync
     {
         private Guid SITE_ID = Guid.NewGuid();
@@ -151,6 +161,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(CommentTestsMemoryCache) ||
+                    this.GetType() == typeof(CommentTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(CommentTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/ContentTests.cs
+++ b/test/Piranha.Tests/Services/ContentTests.cs
@@ -41,6 +41,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class ContentTestsDistributedTwoLevelCache : ContentTests
+    {
+        public override async Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            await base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class ContentTests : BaseTestsAsync
     {
         private readonly Guid ID_1 = Guid.NewGuid();

--- a/test/Piranha.Tests/Services/MediaTests.cs
+++ b/test/Piranha.Tests/Services/MediaTests.cs
@@ -40,6 +40,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class MediaTestsDistributedTwoLevelCache : MediaTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class MediaTests : BaseTestsAsync
     {
         private Guid image1Id;
@@ -157,6 +167,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(MediaTestsMemoryCache) ||
+                    this.GetType() == typeof(MediaTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(MediaTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/PageTests.cs
+++ b/test/Piranha.Tests/Services/PageTests.cs
@@ -45,6 +45,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class PageTestsDistributedTwoLevelCache : PageTests
+    {
+        public override async Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            await base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class PageTests : BaseTestsAsync
     {
         public readonly Guid SITE_ID = Guid.NewGuid();
@@ -287,6 +297,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(PageTestsMemoryCache) ||
+                    this.GetType() == typeof(PageTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(PageTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/PageTypeTests.cs
+++ b/test/Piranha.Tests/Services/PageTypeTests.cs
@@ -38,6 +38,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class PageTypeTestsDistributedTwoLevelCache : PageTypeTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class PageTypeTests : BaseTestsAsync
     {
         private readonly List<PageType> pageTypes = new List<PageType>
@@ -169,6 +179,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(PageTypeTestsMemoryCache) ||
+                    this.GetType() == typeof(PageTypeTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(PageTypeTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/ParamTests.cs
+++ b/test/Piranha.Tests/Services/ParamTests.cs
@@ -39,6 +39,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class ParamTestsDistributedTwoLevelCache : ParamTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class ParamTests : BaseTestsAsync
     {
         private const string PARAM_1 = "MyFirstParam";
@@ -91,6 +101,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(ParamTestsMemoryCache) ||
+                    this.GetType() == typeof(ParamTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(ParamTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/PostTests.cs
+++ b/test/Piranha.Tests/Services/PostTests.cs
@@ -45,6 +45,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class PostTestsDistributedTwoLevelCache : PostTests
+    {
+        public override async Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            await base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class PostTests : BaseTestsAsync
     {
         private readonly Guid SITE_ID = Guid.NewGuid();
@@ -249,6 +259,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(PostTestsMemoryCache) ||
+                    this.GetType() == typeof(PostTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(PostTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/PostTypeTests.cs
+++ b/test/Piranha.Tests/Services/PostTypeTests.cs
@@ -38,6 +38,16 @@ namespace Piranha.Tests.Repositories
     }
 
     [Collection("Integration tests")]
+    public class PostTypeTestsDistributedTwoLevelCache : PostTypeTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class PostTypeTests : BaseTestsAsync
     {
         private readonly List<PostType> postTypes = new List<PostType>
@@ -169,6 +179,7 @@ namespace Piranha.Tests.Repositories
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(PostTypeTestsMemoryCache) ||
+                    this.GetType() == typeof(PostTypeTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(PostTypeTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/SiteTests.cs
+++ b/test/Piranha.Tests/Services/SiteTests.cs
@@ -43,6 +43,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class SiteTestsDistributedTwoLevelCache : SiteTests
+    {
+        public override async Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            await base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class SiteTests : BaseTestsAsync
     {
         private const string SITE_1 = "MyFirstSite";
@@ -198,6 +208,7 @@ namespace Piranha.Tests.Services
             using (var api = CreateApi()) {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(SiteTestsMemoryCache) ||
+                    this.GetType() == typeof(SiteTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(SiteTestsDistributedCache));
             }
         }

--- a/test/Piranha.Tests/Services/SiteTypeTests.cs
+++ b/test/Piranha.Tests/Services/SiteTypeTests.cs
@@ -38,6 +38,16 @@ namespace Piranha.Tests.Services
     }
 
     [Collection("Integration tests")]
+    public class SiteTypeTestsDistributedTwoLevelCache : SiteTypeTests
+    {
+        public override Task InitializeAsync()
+        {
+            _cache = new Cache.DistributedTwoLevelCache((IMemoryCache)_services.GetService(typeof(IMemoryCache)), (IDistributedCache)_services.GetService(typeof(IDistributedCache)));
+            return base.InitializeAsync();
+        }
+    }
+
+    [Collection("Integration tests")]
     public class SiteTypeTests : BaseTestsAsync
     {
         private readonly List<SiteType> siteTypes = new List<SiteType>
@@ -168,6 +178,7 @@ namespace Piranha.Tests.Services
             {
                 Assert.Equal(((Api)api).IsCached,
                     this.GetType() == typeof(SiteTypeTestsMemoryCache) ||
+                    this.GetType() == typeof(SiteTypeTestsDistributedTwoLevelCache) ||
                     this.GetType() == typeof(SiteTypeTestsDistributedCache));
             }
         }


### PR DESCRIPTION
To start I want to say that the default in-memory caching for a single instance works great. It is fast and can handle lots of load. My recommendation is to scale up instead of scale out if it’s possible.

But, I have been looking into the implementation of the distributed cache implementation. Currently it is mainly wrapping the default .NET distributed cache service IDistributedCache. When I tried to use an app service cluster in Azure I ran into some performance issues. Some pages with many blocks added to them didn’t behave well under load tests. After some debugging my conclusion is that the server talks a lot to the cache service. Works great for in-memory caching, but not so good when using a Redis cache or some other cache service that talks over the network.

So my suggestion is to create a simple two level distributed cache. The first level cache is an in-memory cache and the second level is the distributed cache. When something in the second level cache is changed the whole first level cache is invalidated and must be reloaded again. 

I have tried to add functionality so that it doesn’t cause breaking changes for those who use the current distributed cache implementation.
