### PR TITLE
Use a different cache key for ContentInfo in ContentService. Fixes #2041

### DIFF
--- a/core/Piranha/Services/ContentService.cs
+++ b/core/Piranha/Services/ContentService.cs
@@ -132,9 +132,13 @@ public class ContentService : IContentService
         }
 
         // First, try to get the model from cache
-        if (!typeof(DynamicContent).IsAssignableFrom(typeof(T)))
+        if (typeof(T) == typeof(ContentInfo))
         {
-            model = _cache?.Get<GenericContent>($"{ languageId }_{ id }");
+            model = _cache?.Get<GenericContent>($"ContentInfo_{ languageId }_{ id }");
+        }
+        else if (!typeof(DynamicContent).IsAssignableFrom(typeof(T)))
+        {
+            model = _cache?.Get<GenericContent>($"Content_{ languageId }_{ id }");
         }
 
         // If we have a model, let's initialize it
@@ -339,9 +343,13 @@ public class ContentService : IContentService
         if (_cache != null)
         {
             // Store the model
-            if (model is not IDynamicContent)
+            if (model is ContentInfo)
             {
-                _cache.Set($"{ languageId }_{ model.Id }", model);
+                _cache.Set($"ContentInfo_{ languageId }_{ model.Id }", model);
+            }
+            else if (model is not IDynamicContent)
+            {
+                _cache.Set($"Content_{ languageId }_{ model.Id }", model);
             }
         }
     }
@@ -357,7 +365,8 @@ public class ContentService : IContentService
         {
             if (_cache != null)
             {
-                _cache.Remove($"{ languageId }_{ model.Id }");
+                _cache.Remove($"ContentInfo_{ languageId }_{ model.Id }");
+                _cache.Remove($"Content_{ languageId }_{ model.Id }");
             }
         });
     }

--- a/test/Piranha.Tests/Services/ContentTests.cs
+++ b/test/Piranha.Tests/Services/ContentTests.cs
@@ -141,9 +141,12 @@ public class ContentTests : BaseTestsAsync
         using (var api = CreateApi())
         {
             var content = await api.Content.GetByIdAsync<MyContent>(ID_1);
+            var contentInfo = await api.Content.GetByIdAsync<ContentInfo>(ID_1);
 
             Assert.NotNull(content);
+            Assert.NotNull(contentInfo);
             Assert.Equal("My first content", content.Title);
+            Assert.Equal(content.Title, contentInfo.Title);
         }
     }
 
@@ -153,9 +156,12 @@ public class ContentTests : BaseTestsAsync
         using (var api = CreateApi())
         {
             var content = await api.Content.GetByIdAsync<MyContent>(ID_1, ID_LANG);
+            var contentInfo = await api.Content.GetByIdAsync<ContentInfo>(ID_1, ID_LANG);
 
             Assert.NotNull(content);
+            Assert.NotNull(contentInfo);
             Assert.Equal("Mitt första innehåll", content.Title);
+            Assert.Equal(content.Title, contentInfo.Title);
         }
     }
 


### PR DESCRIPTION
Hi guys,

I'm not sure if this was the right thing to do, but I branched this from the v10.4 tag in master. This was just in case there was a need to release this before the next version. Let me know if that was wrong and I'll change my approach for future bug fixes!

Thanks,
Andy