### PR TITLE
Upgrade SixLabors.ImageSharp to v3

### DIFF
--- a/core/Piranha.ImageSharp/ImageSharpProcessor.cs
+++ b/core/Piranha.ImageSharp/ImageSharpProcessor.cs
@@ -55,7 +55,7 @@ public class ImageSharpProcessor : IImageProcessor
     /// <param name="height">The requested height</param>
     public void Crop(Stream source, Stream dest, int width, int height)
     {
-        using (var image = Image.Load(source, out IImageFormat format))
+        using (var image = Image.Load(source))
         {
             image.Mutate(x => x.Crop(new Rectangle
             {
@@ -65,6 +65,7 @@ public class ImageSharpProcessor : IImageProcessor
                 Y = height < image.Height ? (image.Height - height) / 2 : 0
             }));
 
+            var format = GetImageFormat(source);
             image.Save(dest, format);
         }
     }
@@ -79,7 +80,7 @@ public class ImageSharpProcessor : IImageProcessor
     /// <param name="width">The requested width</param>
     public void Scale(Stream source, Stream dest, int width)
     {
-        using (var image = Image.Load(source, out IImageFormat format))
+        using (var image = Image.Load(source))
         {
             int height = (int)Math.Round(width * ((float)image.Height / image.Width));
 
@@ -89,6 +90,7 @@ public class ImageSharpProcessor : IImageProcessor
                 Mode = ResizeMode.Crop
             }));
 
+            var format = GetImageFormat(source);
             image.Save(dest, format);
         }
     }
@@ -104,7 +106,7 @@ public class ImageSharpProcessor : IImageProcessor
     /// <param name="height">The requested height</param>
     public void CropScale(Stream source, Stream dest, int width, int height)
     {
-        using (var image = Image.Load(source, out IImageFormat format))
+        using (var image = Image.Load(source))
         {
             var oldRatio = (float)image.Height / image.Width;
             var newRatio = (float)height / width;
@@ -135,6 +137,7 @@ public class ImageSharpProcessor : IImageProcessor
                 Mode = ResizeMode.Crop
             }));
 
+            var format = GetImageFormat(source);
             image.Save(dest, format);
         }
     }
@@ -146,12 +149,27 @@ public class ImageSharpProcessor : IImageProcessor
     /// <param name="dest">The destination stream</param>
     public void AutoOrient(Stream source, Stream dest)
     {
-        using (var image = Image.Load(source, out IImageFormat format))
+        using (var image = Image.Load(source))
         {
             image.Mutate(x => x.AutoOrient());
+
+            var format = GetImageFormat(source);
             image.Save(dest, format);
 
             dest.Position = 0;
         }
+    }
+
+    /// <summary>
+    /// Gets an image format from the provided stream.
+    /// </summary>
+    /// <param name="source">The image data stream</param>
+    /// <returns>The detected format of the image.</returns>
+    /// <exception cref="UnknownImageFormatException">Thrown if the image format cannot be detected from the provided stream.</exception>
+    private static IImageFormat GetImageFormat(Stream source)
+    {
+        // Reset the stream position to the beginning
+        source.Position = 0;
+        return Image.DetectFormat(source);
     }
 }

--- a/core/Piranha.ImageSharp/Piranha.ImageSharp.csproj
+++ b/core/Piranha.ImageSharp/Piranha.ImageSharp.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
     <ProjectReference Include="..\Piranha\Piranha.csproj" />
   </ItemGroup>
 

--- a/test/Piranha.Tests/ImageSharp/ProcessorTests.cs
+++ b/test/Piranha.Tests/ImageSharp/ProcessorTests.cs
@@ -16,8 +16,10 @@ namespace Piranha.Tests.ImageSharp;
 public class ProcessorTests
 {
     [Fact]
-    public void GetSizeStream() {
-        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png")) {
+    public void GetSizeStream()
+    {
+        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png"))
+        {
             var processor = new ImageSharpProcessor();
 
             processor.GetSize(file, out var width, out var height);
@@ -28,10 +30,13 @@ public class ProcessorTests
     }
 
     [Fact]
-    public void GetSizeBytes() {
-        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png")) {
-            using (var reader = new BinaryReader(file)) {
-                var bytes = reader.ReadBytes((int) file.Length);
+    public void GetSizeBytes()
+    {
+        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png"))
+        {
+            using (var reader = new BinaryReader(file))
+            {
+                var bytes = reader.ReadBytes((int)file.Length);
 
                 var processor = new ImageSharpProcessor();
 
@@ -44,11 +49,14 @@ public class ProcessorTests
     }
 
     [Fact]
-    public void Crop() {
-        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png")) {
+    public void Crop()
+    {
+        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png"))
+        {
             var processor = new ImageSharpProcessor();
 
-            using (var outStream = new MemoryStream()) {
+            using (var outStream = new MemoryStream())
+            {
                 processor.Crop(file, outStream, 640, 480);
 
                 outStream.Position = 0;
@@ -62,11 +70,14 @@ public class ProcessorTests
     }
 
     [Fact]
-    public void Scale() {
-        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png")) {
+    public void Scale()
+    {
+        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png"))
+        {
             var processor = new ImageSharpProcessor();
 
-            using (var outStream = new MemoryStream()) {
+            using (var outStream = new MemoryStream())
+            {
                 processor.Scale(file, outStream, 960);
 
                 outStream.Position = 0;
@@ -80,11 +91,14 @@ public class ProcessorTests
     }
 
     [Fact]
-    public void CropScale() {
-        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png")) {
+    public void CropScale()
+    {
+        using (var file = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png"))
+        {
             var processor = new ImageSharpProcessor();
 
-            using (var outStream = new MemoryStream()) {
+            using (var outStream = new MemoryStream())
+            {
                 processor.CropScale(file, outStream, 640, 480);
 
                 outStream.Position = 0;


### PR DESCRIPTION
This upgrade also fixed the issue that I found in my personal project also have custom code that reference to `ImageSharp`'s lib with newest version. This will break the upload media feature in Piranha manager. 

```
Method not found: 'SixLabors.ImageSharp.Image SixLabors.ImageSharp.Image.Load(System.IO.Stream, SixLabors.ImageSharp.Formats.IImageFormat ByRef)'.
```

Steps to reproduce: 

1. Go to examples project, then add latest version of `SixLabors.ImageSharp` lib to the project. 
2. Run project and go to media in manager. 
3. Upload some image, the above error message will show up.  

