### PR TITLE
Revert Request.Path when using SiteRouting and no route is found.

### DIFF
--- a/core/Piranha.AspNetCore/Http/RoutingMiddleware.cs
+++ b/core/Piranha.AspNetCore/Http/RoutingMiddleware.cs
@@ -69,7 +69,7 @@ public class RoutingMiddleware : MiddlewareBase
             //
             Site site = null;
 
-            var hostname = context.Request.Host.Host;
+            var hostname = context.Request.Host.Value;
 
             if (_options.UseSiteRouting)
             {
@@ -91,7 +91,7 @@ public class RoutingMiddleware : MiddlewareBase
                 // Try to get the requested site by hostname
                 if (site == null)
                 {
-                    site = await api.Sites.GetByHostnameAsync(context.Request.Host.Host)
+                    site = await api.Sites.GetByHostnameAsync(context.Request.Host.Value)
                         .ConfigureAwait(false);
                 }
             }

--- a/core/Piranha.AspNetCore/Http/RoutingMiddleware.cs
+++ b/core/Piranha.AspNetCore/Http/RoutingMiddleware.cs
@@ -468,6 +468,10 @@ public class RoutingMiddleware : MiddlewareBase
                     context.Request.QueryString =
                         new QueryString("?" + strQuery);
                 }
+            } else {
+                _logger?.LogDebug("No route found");
+                // No route found. Reset the path to raw path because site routing might have changed it. 
+                context.Request.Path = new PathString(service.Request.Url);
             }
         }
         await _next.Invoke(context);

--- a/core/Piranha.Azure.BlobStorage/BlobStorage.cs
+++ b/core/Piranha.Azure.BlobStorage/BlobStorage.cs
@@ -37,16 +37,18 @@ public class BlobStorage : IStorage, IStorageSession
     /// </param>
     /// <param name="tokenCredential">The connection credentials</param>
     /// <param name="naming">How uploaded media files should be named</param>
+    /// <param name="blobPublicAccessType">Public container access type when creating container.</param>
     public BlobStorage(
         Uri blobContainerUri,
         TokenCredential tokenCredential,
-        BlobStorageNaming naming = BlobStorageNaming.UniqueFileNames)
+        BlobStorageNaming naming = BlobStorageNaming.UniqueFileNames,
+        PublicAccessType blobPublicAccessType = PublicAccessType.None)
     {
         _blobContainerClient = new BlobContainerClient(blobContainerUri, tokenCredential);
         _naming = naming;
 
         // Ensure that blob container exists
-        _blobContainerClient.CreateIfNotExists(PublicAccessType.Blob);
+        _blobContainerClient.CreateIfNotExists(blobPublicAccessType);
     }
 
     /// <summary>

--- a/core/Piranha.Azure.BlobStorage/Extensions/BlobStorageExtensions.cs
+++ b/core/Piranha.Azure.BlobStorage/Extensions/BlobStorageExtensions.cs
@@ -9,6 +9,7 @@
  */
 
 using Azure.Core;
+using Azure.Storage.Blobs.Models;
 using Microsoft.Extensions.DependencyInjection;
 using Piranha;
 using Piranha.Azure;
@@ -71,18 +72,20 @@ public static class BlobStorageExtensions
     /// </param>
     /// <param name="naming">How uploaded media files should be named</param>
     /// <param name="scope">The optional service scope. Default is singleton</param>
+    /// <param name="blobPublicAccessType">Public container access type when creating container.</param>
     /// <returns>The service collection</returns>
     public static IServiceCollection AddPiranhaBlobStorage(
         this IServiceCollection services,
         Uri blobContainerUri,
         TokenCredential credential,
         BlobStorageNaming naming = BlobStorageNaming.UniqueFileNames,
-        ServiceLifetime scope = ServiceLifetime.Singleton)
+        ServiceLifetime scope = ServiceLifetime.Singleton,
+        PublicAccessType blobPublicAccessType = PublicAccessType.None)
     {
         App.Modules.Register<BlobStorageModule>();
 
         services.Add(new ServiceDescriptor(typeof(IStorage), sp =>
-            new BlobStorage(blobContainerUri, credential, naming), scope));
+            new BlobStorage(blobContainerUri, credential, naming, blobPublicAccessType), scope));
 
         return services;
     }


### PR DESCRIPTION
Example:

You're using SiteRouting with a site defined under www.foo.com/en-us.

You also have controllers/endpoints under www.foo.com/en-us that isn't handled by Piranha. For example www.foo.com/en-us/bar.

When RoutingMiddleware gets the request it will find a matching site for www.foo.com/en-us/bar. It will then change the Request.Path to www.foo.com/bar. It will then proceed to try to find a Page in this site for the slug /bar. If it finds one, it will then add that Pages path to the route as intended.

However if it does not find a page. You would want Piranha to skip this request and pass it as-is to the underlying framework. But the path has been changed to www.foo.com/bar in a previous step when looking up the site. In this case, I set the Request.Path back to the raw original path of the request, so that the request is skipped properly and forwarded to the underlying framework as www.foo.com/en-us/bar.

