### PR TITLE
Fix Block.GetTitle

### DIFF
--- a/core/Piranha/Extend/Block.cs
+++ b/core/Piranha/Extend/Block.cs
@@ -32,19 +32,6 @@ public abstract class Block
     public virtual string GetTitle()
     {
         var blockType = App.Blocks.GetByType(GetType());
-        var title = "[Not Implemented]";
-
-        if (!string.IsNullOrEmpty(blockType.ListTitleField))
-        {
-            var prop = GetType().GetProperty(blockType.ListTitleField, App.PropertyBindings);
-
-            if (prop != null && typeof(IField).IsAssignableFrom(prop.PropertyType))
-            {
-                var field = (IField)prop.GetValue(this);
-
-                title = field.GetTitle();
-            }
-        }
-        return title;
+        return blockType.ListTitleField ?? "[Not Implemented]";
     }
 }


### PR DESCRIPTION
The previous implementation tried to get a property with name = the value you set in the ListTitle property of the BlockType attribute.

For example:
`[BlockType(Name = "MyBlock", ListTitle = "MyBlock in a list")]`

Then GetTitle tried to get a property named "MyBlock in a list" from the block instance, which of course always returned null.