### PR TITLE
Removed AutoMapper from EF data mapping

### DIFF
--- a/data/Piranha.Data.EF/Mapping/DataModelMapper.cs
+++ b/data/Piranha.Data.EF/Mapping/DataModelMapper.cs
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) .NET Foundation and Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core
+ *
+ */
+
+using Piranha.Extend.Fields;
+
+namespace Piranha.Data.EF.Mapping;
+
+internal static class DataModelMapper
+{
+    public static void MapToModel<TField>(Data.ContentBase<TField> source, Models.ContentBase target)
+        where TField : Data.ContentFieldBase
+    {
+        switch (source)
+        {
+            case Data.Content content when target is Models.GenericContent model:
+                Map(content, model);
+                break;
+            case Data.Page page when target is Models.PageBase model:
+                Map(page, model);
+                break;
+            case Data.Post post when target is Models.PostBase model:
+                Map(post, model);
+                break;
+            case Data.Site site when target is Models.SiteContentBase model:
+                Map(site, model);
+                break;
+            default:
+                MapContentBase(source, target);
+                break;
+        }
+    }
+
+    public static void MapToData<TField>(Models.ContentBase source, Data.ContentBase<TField> target)
+        where TField : Data.ContentFieldBase
+    {
+        switch (source)
+        {
+            case Models.GenericContent model when target is Data.Content content:
+                Map(model, content);
+                break;
+            case Models.PageBase model when target is Data.Page page:
+                Map(model, page);
+                break;
+            case Models.PostBase model when target is Data.Post post:
+                Map(model, post);
+                break;
+            case Models.SiteContentBase model when target is Data.Site site:
+                Map(model, site);
+                break;
+            default:
+                MapContentBase(source, target);
+                break;
+        }
+    }
+
+    public static void Map(Data.ContentTranslation source, Models.GenericContent target)
+    {
+        target.Title = source.Title;
+        target.Excerpt = source.Excerpt;
+    }
+
+    public static Models.SitemapItem Map(Data.Page source)
+    {
+        return new Models.SitemapItem
+        {
+            Id = source.Id,
+            OriginalPageId = source.OriginalPageId,
+            ParentId = source.ParentId,
+            SortOrder = source.SortOrder,
+            Title = source.Title,
+            NavigationTitle = source.NavigationTitle,
+            MetaIndex = source.MetaIndex ?? true,
+            MetaPriority = source.MetaPriority,
+            Permalink = !source.ParentId.HasValue && source.SortOrder == 0 ? "/" : "/" + source.Slug,
+            IsHidden = source.IsHidden,
+            Published = source.Published,
+            Created = source.Created,
+            LastModified = source.LastModified,
+            Permissions = source.Permissions.Select(p => p.Permission).ToList()
+        };
+    }
+
+    public static Models.MediaStructureItem Map(Data.MediaFolder source)
+    {
+        return new Models.MediaStructureItem
+        {
+            Id = source.Id,
+            Name = source.Name,
+            Created = source.Created
+        };
+    }
+
+    public static Models.ContentGroup Map(Data.ContentGroup source)
+    {
+        return new Models.ContentGroup
+        {
+            Id = source.Id,
+            CLRType = source.CLRType,
+            Title = source.Title,
+            Icon = source.Icon,
+            IsHidden = source.IsHidden
+        };
+    }
+
+    public static void Map(Models.ContentGroup source, Data.ContentGroup target)
+    {
+        target.Id = source.Id;
+        target.CLRType = source.CLRType;
+        target.Title = source.Title;
+        target.Icon = source.Icon;
+        target.IsHidden = source.IsHidden;
+    }
+
+    private static void Map(Data.Content source, Models.GenericContent target)
+    {
+        MapContentBase(source, target);
+
+        target.TypeId = source.TypeId;
+        target.PrimaryImage = ToImageField(source.PrimaryImageId);
+        target.Excerpt = source.Excerpt;
+    }
+
+    private static void Map(Models.GenericContent source, Data.Content target)
+    {
+        MapContentBase(source, target);
+
+        target.TypeId = source.TypeId;
+        target.PrimaryImageId = source.PrimaryImage?.Id;
+        target.Excerpt = source.Excerpt;
+    }
+
+    private static void Map(Data.Page source, Models.PageBase target)
+    {
+        MapRoutedContentBase(source, target);
+
+        target.TypeId = source.PageTypeId;
+        target.SiteId = source.SiteId;
+        target.ParentId = source.ParentId;
+        target.SortOrder = source.SortOrder;
+        target.NavigationTitle = source.NavigationTitle;
+        target.IsHidden = source.IsHidden;
+        target.OriginalPageId = source.OriginalPageId;
+        target.Permalink = "/" + source.Slug;
+    }
+
+    private static void Map(Models.PageBase source, Data.Page target)
+    {
+        MapRoutedContentBase(source, target);
+
+        target.PageTypeId = source.TypeId;
+        target.SiteId = source.SiteId;
+        target.ParentId = source.ParentId;
+        target.SortOrder = source.SortOrder;
+        target.NavigationTitle = source.NavigationTitle;
+        target.IsHidden = source.IsHidden;
+        target.OriginalPageId = source.OriginalPageId;
+    }
+
+    private static void Map(Data.Post source, Models.PostBase target)
+    {
+        MapRoutedContentBase(source, target);
+
+        target.TypeId = source.PostTypeId;
+        target.BlogId = source.BlogId;
+        target.Category = source.Category != null ? ToTaxonomy(source.Category) : null;
+        target.Tags = source.Tags.Select(ToTaxonomy).ToList();
+    }
+
+    private static void Map(Models.PostBase source, Data.Post target)
+    {
+        MapRoutedContentBase(source, target);
+
+        target.PostTypeId = source.TypeId;
+        target.BlogId = source.BlogId;
+        if (source.Category != null)
+        {
+            target.CategoryId = source.Category.Id;
+        }
+    }
+
+    private static void Map(Data.Site source, Models.SiteContentBase target)
+    {
+        MapContentBase(source, target);
+
+        target.TypeId = source.SiteTypeId;
+    }
+
+    private static void Map(Models.SiteContentBase source, Data.Site target)
+    {
+        target.Id = source.Id;
+        target.Title = source.Title;
+    }
+
+    private static void MapContentBase<TField>(Data.ContentBase<TField> source, Models.ContentBase target)
+        where TField : Data.ContentFieldBase
+    {
+        target.Id = source.Id;
+        target.Title = source.Title;
+        target.Created = source.Created;
+        target.LastModified = source.LastModified;
+    }
+
+    private static void MapContentBase<TField>(Models.ContentBase source, Data.ContentBase<TField> target)
+        where TField : Data.ContentFieldBase
+    {
+        target.Id = source.Id;
+        target.Title = source.Title;
+    }
+
+    private static void MapRoutedContentBase<TField>(Data.RoutedContentBase<TField> source, Models.RoutedContentBase target)
+        where TField : Data.ContentFieldBase
+    {
+        MapContentBase(source, target);
+
+        target.Slug = source.Slug;
+        target.MetaTitle = source.MetaTitle;
+        target.MetaKeywords = source.MetaKeywords;
+        target.MetaDescription = source.MetaDescription;
+        target.MetaIndex = source.MetaIndex ?? true;
+        target.MetaFollow = source.MetaFollow ?? true;
+        target.MetaPriority = source.MetaPriority;
+        target.OgTitle = source.OgTitle;
+        target.OgDescription = source.OgDescription;
+        target.OgImage = ToImageField(source.OgImageId);
+        target.Route = source.Route;
+        target.Published = source.Published;
+        target.PrimaryImage = ToImageField(GetPrimaryImageId(source));
+        target.Excerpt = GetExcerpt(source);
+        target.RedirectUrl = GetRedirectUrl(source);
+        target.RedirectType = GetRedirectType(source);
+        target.EnableComments = GetEnableComments(source);
+        target.CloseCommentsAfterDays = GetCloseCommentsAfterDays(source);
+    }
+
+    private static void MapRoutedContentBase<TField>(Models.RoutedContentBase source, Data.RoutedContentBase<TField> target)
+        where TField : Data.ContentFieldBase
+    {
+        MapContentBase(source, target);
+
+        target.Slug = source.Slug;
+        target.MetaTitle = source.MetaTitle;
+        target.MetaKeywords = source.MetaKeywords;
+        target.MetaDescription = source.MetaDescription;
+        target.MetaIndex = source.MetaIndex;
+        target.MetaFollow = source.MetaFollow;
+        target.MetaPriority = source.MetaPriority;
+        target.OgTitle = source.OgTitle;
+        target.OgDescription = source.OgDescription;
+        target.OgImageId = source.OgImage?.Id ?? Guid.Empty;
+        target.Route = source.Route;
+        target.Published = source.Published;
+
+        switch (target)
+        {
+            case Data.Page page:
+                page.PrimaryImageId = source.PrimaryImage?.Id;
+                page.Excerpt = source.Excerpt;
+                page.RedirectUrl = source.RedirectUrl;
+                page.RedirectType = source.RedirectType;
+                page.EnableComments = source.EnableComments;
+                page.CloseCommentsAfterDays = source.CloseCommentsAfterDays;
+                break;
+            case Data.Post post:
+                post.PrimaryImageId = source.PrimaryImage?.Id;
+                post.Excerpt = source.Excerpt;
+                post.RedirectUrl = source.RedirectUrl;
+                post.RedirectType = source.RedirectType;
+                post.EnableComments = source.EnableComments;
+                post.CloseCommentsAfterDays = source.CloseCommentsAfterDays;
+                break;
+        }
+    }
+
+    private static ImageField ToImageField(Guid? id)
+    {
+        return new ImageField { Id = id };
+    }
+
+    private static ImageField ToImageField(Guid id)
+    {
+        return new ImageField { Id = id };
+    }
+
+    private static Models.Taxonomy ToTaxonomy(Data.Category source)
+    {
+        return new Models.Taxonomy
+        {
+            Id = source.Id,
+            Title = source.Title,
+            Slug = source.Slug,
+            Type = Models.TaxonomyType.Category
+        };
+    }
+
+    private static Models.Taxonomy ToTaxonomy(Data.Tag source)
+    {
+        return new Models.Taxonomy
+        {
+            Id = source.Id,
+            Title = source.Title,
+            Slug = source.Slug,
+            Type = Models.TaxonomyType.Tag
+        };
+    }
+
+    private static Models.Taxonomy ToTaxonomy(Data.PostTag source)
+    {
+        return new Models.Taxonomy
+        {
+            Id = source.TagId,
+            Title = source.Tag?.Title,
+            Slug = source.Tag?.Slug,
+            Type = Models.TaxonomyType.Tag
+        };
+    }
+
+    private static Guid? GetPrimaryImageId<TField>(Data.RoutedContentBase<TField> source)
+        where TField : Data.ContentFieldBase
+    {
+        return source switch
+        {
+            Data.Page page => page.PrimaryImageId,
+            Data.Post post => post.PrimaryImageId,
+            _ => null
+        };
+    }
+
+    private static string GetExcerpt<TField>(Data.RoutedContentBase<TField> source)
+        where TField : Data.ContentFieldBase
+    {
+        return source switch
+        {
+            Data.Page page => page.Excerpt,
+            Data.Post post => post.Excerpt,
+            _ => null
+        };
+    }
+
+    private static string GetRedirectUrl<TField>(Data.RoutedContentBase<TField> source)
+        where TField : Data.ContentFieldBase
+    {
+        return source switch
+        {
+            Data.Page page => page.RedirectUrl,
+            Data.Post post => post.RedirectUrl,
+            _ => null
+        };
+    }
+
+    private static Models.RedirectType GetRedirectType<TField>(Data.RoutedContentBase<TField> source)
+        where TField : Data.ContentFieldBase
+    {
+        return source switch
+        {
+            Data.Page page => page.RedirectType,
+            Data.Post post => post.RedirectType,
+            _ => Models.RedirectType.Temporary
+        };
+    }
+
+    private static bool GetEnableComments<TField>(Data.RoutedContentBase<TField> source)
+        where TField : Data.ContentFieldBase
+    {
+        return source switch
+        {
+            Data.Page page => page.EnableComments,
+            Data.Post post => post.EnableComments,
+            _ => false
+        };
+    }
+
+    private static int GetCloseCommentsAfterDays<TField>(Data.RoutedContentBase<TField> source)
+        where TField : Data.ContentFieldBase
+    {
+        return source switch
+        {
+            Data.Page page => page.CloseCommentsAfterDays,
+            Data.Post post => post.CloseCommentsAfterDays,
+            _ => 0
+        };
+    }
+}

--- a/data/Piranha.Data.EF/Mapping/DataModelMapper.cs
+++ b/data/Piranha.Data.EF/Mapping/DataModelMapper.cs
@@ -275,6 +275,8 @@ internal static class DataModelMapper
                 post.EnableComments = source.EnableComments;
                 post.CloseCommentsAfterDays = source.CloseCommentsAfterDays;
                 break;
+            default:
+                throw new NotSupportedException($"Unsupported routed content data type {target.GetType().FullName}.");
         }
     }
 

--- a/data/Piranha.Data.EF/Module.cs
+++ b/data/Piranha.Data.EF/Module.cs
@@ -8,7 +8,6 @@
  *
  */
 
-using AutoMapper;
 using Piranha.Extend;
 
 namespace Piranha.Data.EF;
@@ -18,8 +17,6 @@ namespace Piranha.Data.EF;
 /// </summary>
 public class Module : IModule
 {
-    public static IMapper Mapper { get; private set; }
-
     /// <summary>
     /// Gets the Author
     /// </summary>
@@ -49,143 +46,6 @@ public class Module : IModule
     /// Gets the icon url.
     /// </summary>
     public string IconUrl => "https://piranhacms.org/assets/twitter-shield.png";
-
-    /// <summary>
-    /// Create automapping.
-    /// </summary>
-    static Module()
-    {
-        var mapperConfig = new MapperConfiguration(cfg =>
-        {
-            cfg.CreateMap<Data.Alias, Data.Alias>()
-                .ForMember(a => a.Id, o => o.Ignore())
-                .ForMember(a => a.Created, o => o.Ignore());
-            cfg.CreateMap<Data.Category, Data.Category>()
-                .ForMember(c => c.Id, o => o.Ignore())
-                .ForMember(c => c.Created, o => o.Ignore());
-            cfg.CreateMap<Data.Category, Models.Taxonomy>()
-                .ForMember(c => c.Type, o => o.MapFrom(m => Models.TaxonomyType.Category));
-            cfg.CreateMap<Data.Content, Models.GenericContent>()
-                .ForMember(p => p.PrimaryImage, o => o.MapFrom(m => m.PrimaryImageId))
-                .ForMember(p => p.Permissions, o => o.Ignore());
-            cfg.CreateMap<Models.GenericContent, Data.Content>()
-                .ForMember(c => c.CategoryId, o => o.Ignore())
-                .ForMember(c => c.Category, o => o.Ignore())
-                .ForMember(c => c.Blocks, o => o.Ignore())
-                .ForMember(c => c.Fields, o => o.Ignore())
-                .ForMember(c => c.Tags, o => o.Ignore())
-                .ForMember(c => c.Type, o => o.Ignore())
-                .ForMember(c => c.Translations, o => o.Ignore())
-                .ForMember(c => c.Created, o => o.Ignore())
-                .ForMember(c => c.LastModified, o => o.Ignore());
-            cfg.CreateMap<Data.ContentGroup, Models.ContentGroup>();
-            cfg.CreateMap<Models.ContentGroup, Data.ContentGroup>()
-                .ForMember(g => g.Created, o => o.Ignore())
-                .ForMember(g => g.LastModified, o => o.Ignore());
-            cfg.CreateMap<Data.ContentTranslation, Models.GenericContent>()
-                .ForMember(c =>  c.Id, o => o.Ignore())
-                .ForMember(c =>  c.TypeId, o => o.Ignore())
-                .ForMember(c =>  c.PrimaryImage, o => o.Ignore())
-                .ForMember(c =>  c.Created, o => o.Ignore())
-                .ForMember(c =>  c.LastModified, o => o.Ignore())
-                .ForMember(c =>  c.Permissions, o => o.Ignore());
-            cfg.CreateMap<Data.MediaFolder, Data.MediaFolder>()
-                .ForMember(f => f.Id, o => o.Ignore())
-                .ForMember(f => f.Created, o => o.Ignore())
-                .ForMember(f => f.Media, o => o.Ignore());
-            cfg.CreateMap<Data.MediaFolder, Models.MediaStructureItem>()
-                .ForMember(f => f.Level, o => o.Ignore())
-                .ForMember(f => f.FolderCount, o => o.Ignore())
-                .ForMember(f => f.MediaCount, o => o.Ignore())
-                .ForMember(f => f.Items, o => o.Ignore());
-            cfg.CreateMap<Data.Page, Models.PageBase>()
-                .ForMember(p => p.TypeId, o => o.MapFrom(m => m.PageTypeId))
-                .ForMember(p => p.PrimaryImage, o => o.MapFrom(m => m.PrimaryImageId))
-                .ForMember(p => p.OgImage, o => o.MapFrom(m => m.OgImageId))
-                .ForMember(p => p.Permalink, o => o.MapFrom(m => "/" + m.Slug))
-                .ForMember(p => p.Permissions, o => o.Ignore())
-                .ForMember(p => p.Blocks, o => o.Ignore())
-                .ForMember(p => p.CommentCount, o => o.Ignore());
-            cfg.CreateMap<Models.PageBase, Data.Page>()
-                .ForMember(p => p.ContentType, o => o.Ignore())
-                .ForMember(p => p.PrimaryImageId, o => o.MapFrom(m => m.PrimaryImage != null ? m.PrimaryImage.Id : (Guid?)null ))
-                .ForMember(p => p.OgImageId, o => o.MapFrom(m => m.OgImage != null ? m.OgImage.Id : (Guid?)null ))
-                .ForMember(p => p.PageTypeId, o => o.MapFrom(m => m.TypeId))
-                .ForMember(p => p.Blocks, o => o.Ignore())
-                .ForMember(p => p.Fields, o => o.Ignore())
-                .ForMember(p => p.Created, o => o.Ignore())
-                .ForMember(p => p.LastModified, o => o.Ignore())
-                .ForMember(p => p.Permissions, o => o.Ignore())
-                .ForMember(p => p.PageType, o => o.Ignore())
-                .ForMember(p => p.Site, o => o.Ignore())
-                .ForMember(p => p.Parent, o => o.Ignore());
-            cfg.CreateMap<Data.Page, Models.SitemapItem>()
-                .ForMember(p => p.MenuTitle, o => o.Ignore())
-                .ForMember(p => p.Level, o => o.Ignore())
-                .ForMember(p => p.Items, o => o.Ignore())
-                .ForMember(p => p.PageTypeName, o => o.Ignore())
-                .ForMember(p => p.Permalink, o => o.MapFrom(d => !d.ParentId.HasValue && d.SortOrder == 0 ? "/" : "/" + d.Slug))
-                .ForMember(p => p.Permissions, o => o.MapFrom(d => d.Permissions.Select(dp => dp.Permission).ToList()));
-            cfg.CreateMap<Data.Param, Data.Param>()
-                .ForMember(p => p.Id, o => o.Ignore())
-                .ForMember(p => p.Created, o => o.Ignore());
-            cfg.CreateMap<Data.Post, Models.PostBase>()
-                .ForMember(p => p.TypeId, o => o.MapFrom(m => m.PostTypeId))
-                .ForMember(p => p.PrimaryImage, o => o.MapFrom(m => m.PrimaryImageId))
-                .ForMember(p => p.OgImage, o => o.MapFrom(m => m.OgImageId))
-                .ForMember(p => p.Permalink, o => o.Ignore())
-                .ForMember(p => p.Permissions, o => o.Ignore())
-                .ForMember(p => p.Blocks, o => o.Ignore())
-                .ForMember(p => p.CommentCount, o => o.Ignore());
-            cfg.CreateMap<Data.PostTag, Models.Taxonomy>()
-                .ForMember(p => p.Id, o => o.MapFrom(m => m.TagId))
-                .ForMember(p => p.Title, o => o.MapFrom(m => m.Tag.Title))
-                .ForMember(p => p.Slug, o => o.MapFrom(m => m.Tag.Slug))
-                .ForMember(p => p.Type, o => o.MapFrom(m => Models.TaxonomyType.Tag));
-            cfg.CreateMap<Models.PostBase, Data.Post>()
-                .ForMember(p => p.PostTypeId, o => o.MapFrom(m => m.TypeId))
-                .ForMember(p => p.CategoryId, o => o.MapFrom(m => m.Category.Id))
-                .ForMember(p => p.PrimaryImageId, o => o.MapFrom(m => m.PrimaryImage != null ? m.PrimaryImage.Id : (Guid?)null ))
-                .ForMember(p => p.OgImageId, o => o.MapFrom(m => m.OgImage != null ? m.OgImage.Id : (Guid?)null ))
-                .ForMember(p => p.Blocks, o => o.Ignore())
-                .ForMember(p => p.Fields, o => o.Ignore())
-                .ForMember(p => p.Created, o => o.Ignore())
-                .ForMember(p => p.LastModified, o => o.Ignore())
-                .ForMember(p => p.Permissions, o => o.Ignore())
-                .ForMember(p => p.PostType, o => o.Ignore())
-                .ForMember(p => p.Blog, o => o.Ignore())
-                .ForMember(p => p.Category, o => o.Ignore())
-                .ForMember(p => p.Tags, o => o.Ignore());
-            cfg.CreateMap<Data.Site, Data.Site>()
-                .ForMember(s => s.Id, o => o.Ignore())
-                .ForMember(s => s.Language, o => o.Ignore())
-                .ForMember(s => s.Created, o => o.Ignore());
-            cfg.CreateMap<Data.Site, Models.SiteContentBase>()
-                .ForMember(s => s.TypeId, o => o.MapFrom(m => m.SiteTypeId))
-                .ForMember(s => s.Permissions, o => o.Ignore());
-            cfg.CreateMap<Models.SiteContentBase, Data.Site>()
-                .ForMember(s => s.LanguageId, o => o.Ignore())
-                .ForMember(s => s.SiteTypeId, o => o.Ignore())
-                .ForMember(s => s.InternalId, o => o.Ignore())
-                .ForMember(s => s.Description, o => o.Ignore())
-                .ForMember(s => s.LogoId, o => o.Ignore())
-                .ForMember(s => s.Hostnames, o => o.Ignore())
-                .ForMember(s => s.IsDefault, o => o.Ignore())
-                .ForMember(s => s.Culture, o => o.Ignore())
-                .ForMember(s => s.Fields, o => o.Ignore())
-                .ForMember(s => s.Language, o => o.Ignore())
-                .ForMember(s => s.Created, o => o.Ignore())
-                .ForMember(s => s.LastModified, o => o.Ignore())
-                .ForMember(s => s.ContentLastModified, o => o.Ignore());
-            cfg.CreateMap<Data.Tag, Data.Tag>()
-                .ForMember(t => t.Id, o => o.Ignore())
-                .ForMember(t => t.Created, o => o.Ignore());
-            cfg.CreateMap<Data.Tag, Models.Taxonomy>()
-                .ForMember(t => t.Type, o => o.MapFrom(m => Models.TaxonomyType.Tag));
-        });
-        mapperConfig.AssertConfigurationIsValid();
-        Mapper = mapperConfig.CreateMapper();
-    }
 
     /// <summary>
     /// Initializes the module.

--- a/data/Piranha.Data.EF/Piranha.Data.EF.csproj
+++ b/data/Piranha.Data.EF/Piranha.Data.EF.csproj
@@ -16,7 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <ProjectReference Include="..\..\core\Piranha\Piranha.csproj" />
   </ItemGroup>
 

--- a/data/Piranha.Data.EF/Repositories/ContentGroupRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/ContentGroupRepository.cs
@@ -10,6 +10,7 @@
 
 using Microsoft.EntityFrameworkCore;
 using Piranha.Data.EF;
+using Piranha.Data.EF.Mapping;
 using Piranha.Models;
 
 namespace Piranha.Repositories;
@@ -42,7 +43,7 @@ internal class ContentGroupRepository : IContentGroupRepository
 
         foreach (var group in groups)
         {
-            models.Add(Module.Mapper.Map<Data.ContentGroup, ContentGroup>(group));
+            models.Add(DataModelMapper.Map(group));
         }
         return models;
     }
@@ -61,7 +62,7 @@ internal class ContentGroupRepository : IContentGroupRepository
 
         if (group != null)
         {
-            return Module.Mapper.Map<Data.ContentGroup, ContentGroup>(group);
+            return DataModelMapper.Map(group);
         }
         return null;
     }
@@ -85,7 +86,7 @@ internal class ContentGroupRepository : IContentGroupRepository
             };
             await _db.ContentGroups.AddAsync(group).ConfigureAwait(false);
         }
-        Module.Mapper.Map<ContentGroup, Data.ContentGroup>(model, group);
+        DataModelMapper.Map(model, group);
         group.LastModified = DateTime.Now;
 
         await _db.SaveChangesAsync().ConfigureAwait(false);

--- a/data/Piranha.Data.EF/Repositories/MediaRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/MediaRepository.cs
@@ -11,6 +11,7 @@
 using Microsoft.EntityFrameworkCore;
 using Piranha.Data;
 using Piranha.Data.EF;
+using Piranha.Data.EF.Mapping;
 
 namespace Piranha.Repositories;
 
@@ -308,7 +309,7 @@ internal class MediaRepository : IMediaRepository
         var mediaFolders = folders as MediaFolder[] ?? folders.ToArray();
         foreach (var folder in mediaFolders.Where(f => f.ParentId == parentId).OrderBy(f => f.Name))
         {
-            var item = Module.Mapper.Map<MediaFolder, Models.MediaStructureItem>(folder);
+            var item = DataModelMapper.Map(folder);
             var folderCount = count.FirstOrDefault(c => c.FolderId == folder.Id)?.Count;
 
             item.Level = level;

--- a/data/Piranha.Data.EF/Repositories/SiteRepository.cs
+++ b/data/Piranha.Data.EF/Repositories/SiteRepository.cs
@@ -11,6 +11,7 @@
 using Microsoft.EntityFrameworkCore;
 using Piranha.Data;
 using Piranha.Data.EF;
+using Piranha.Data.EF.Mapping;
 using Piranha.Extend.Fields;
 using Piranha.Services;
 
@@ -373,7 +374,7 @@ internal class SiteRepository : ISiteRepository
 
         foreach (var page in pages.Where(p => p.ParentId == parentId).OrderBy(p => p.SortOrder))
         {
-            var item = Module.Mapper.Map<Page, Models.SitemapItem>(page);
+            var item = DataModelMapper.Map(page);
 
             if (!string.IsNullOrEmpty(page.RedirectUrl))
             {

--- a/data/Piranha.Data.EF/Services/IContentServiceFactory.cs
+++ b/data/Piranha.Data.EF/Services/IContentServiceFactory.cs
@@ -8,8 +8,6 @@
  *
  */
 
-using AutoMapper;
-
 namespace Piranha.Services;
 
 /// <summary>
@@ -20,9 +18,8 @@ public interface IContentServiceFactory
     /// <summary>
     /// Creates a new content service for the specified types.
     /// </summary>
-    /// <param name="mapper">The AutoMapper instance to use for transformation</param>
     /// <returns>The content service</returns>
-    IContentService<TContent, TField, TModelBase> Create<TContent, TField, TModelBase>(IMapper mapper)
+    IContentService<TContent, TField, TModelBase> Create<TContent, TField, TModelBase>()
         where TContent : Data.ContentBase<TField>
         where TField : Data.ContentFieldBase
         where TModelBase : Models.ContentBase;

--- a/data/Piranha.Data.EF/Services/Internal/ContentService.cs
+++ b/data/Piranha.Data.EF/Services/Internal/ContentService.cs
@@ -10,8 +10,8 @@
 
 using System.Collections;
 using System.Dynamic;
-using AutoMapper;
 using Piranha.Data;
+using Piranha.Data.EF.Mapping;
 using Piranha.Models;
 
 namespace Piranha.Services;
@@ -25,17 +25,14 @@ internal class ContentService<TContent, TField, TModelBase> : IContentService<TC
     //
     // Members
     protected readonly IContentFactory _factory;
-    protected readonly IMapper _mapper;
 
     /// <summary>
     /// Default constructor.
     /// </summary>
     /// <param name="factory">The content factory</param>
-    /// <param name="mapper">The AutoMapper instance to use</param>
-    public ContentService(IContentFactory factory, IMapper mapper)
+    public ContentService(IContentFactory factory)
     {
         _factory = factory;
-        _mapper = mapper;
     }
 
     /// <inheritdoc />
@@ -72,7 +69,7 @@ internal class ContentService<TContent, TField, TModelBase> : IContentService<TC
             //
             // 3: Map basic fields
             //
-            _mapper.Map<TContent, TModelBase>(content, model);
+            DataModelMapper.MapToModel(content, model);
 
             //
             // 4: Map routes
@@ -93,7 +90,10 @@ internal class ContentService<TContent, TField, TModelBase> : IContentService<TC
 
                 if (translation != null)
                 {
-                    _mapper.Map(translation, model);
+                    if (model is Models.GenericContent genericModel && translation is ContentTranslation contentTranslation)
+                    {
+                        DataModelMapper.Map(contentTranslation, genericModel);
+                    }
                 }
             }
 
@@ -185,7 +185,7 @@ internal class ContentService<TContent, TField, TModelBase> : IContentService<TC
         //
         // 2: Map basic fields
         //
-        _mapper.Map<TModelBase, TContent>(model, content);
+        DataModelMapper.MapToData(model, content);
 
         //
         // 3: Map translation

--- a/data/Piranha.Data.EF/Services/Internal/ContentServiceFactory.cs
+++ b/data/Piranha.Data.EF/Services/Internal/ContentServiceFactory.cs
@@ -8,9 +8,6 @@
  *
  */
 
-using AutoMapper;
-using Piranha.Data.EF;
-
 namespace Piranha.Services;
 
 /// <inheritdoc />
@@ -28,35 +25,35 @@ internal class ContentServiceFactory : IContentServiceFactory
     }
 
     /// <inheritdoc />
-    public IContentService<TContent, TField, TModelBase> Create<TContent, TField, TModelBase>(IMapper mapper)
+    public IContentService<TContent, TField, TModelBase> Create<TContent, TField, TModelBase>()
         where TContent : Data.ContentBase<TField>
         where TField : Data.ContentFieldBase
         where TModelBase : Models.ContentBase
     {
-        return new ContentService<TContent, TField, TModelBase>(_factory, mapper);
+        return new ContentService<TContent, TField, TModelBase>(_factory);
     }
 
     /// <inheritdoc />
     public IContentService<Data.Content, Data.ContentField, Models.GenericContent> CreateContentService()
     {
-        return new ContentService<Data.Content, Data.ContentField, Models.GenericContent>(_factory, Module.Mapper);
+        return new ContentService<Data.Content, Data.ContentField, Models.GenericContent>(_factory);
     }
 
     /// <inheritdoc />
     public IContentService<Data.Page, Data.PageField, Models.PageBase> CreatePageService()
     {
-        return new ContentService<Data.Page, Data.PageField, Models.PageBase>(_factory, Module.Mapper);
+        return new ContentService<Data.Page, Data.PageField, Models.PageBase>(_factory);
     }
 
     /// <inheritdoc />
     public IContentService<Data.Post, Data.PostField, Models.PostBase> CreatePostService()
     {
-        return new ContentService<Data.Post, Data.PostField, Models.PostBase>(_factory, Module.Mapper);
+        return new ContentService<Data.Post, Data.PostField, Models.PostBase>(_factory);
     }
 
     /// <inheritdoc />
     public IContentService<Data.Site, Data.SiteField, Models.SiteContentBase> CreateSiteService()
     {
-        return new ContentService<Data.Site, Data.SiteField, Models.SiteContentBase>(_factory, Module.Mapper);
+        return new ContentService<Data.Site, Data.SiteField, Models.SiteContentBase>(_factory);
     }
 }

--- a/test/Piranha.Tests/Blocks.cs
+++ b/test/Piranha.Tests/Blocks.cs
@@ -29,7 +29,7 @@ public class Blocks : BaseTestsAsync
         {
             Piranha.App.Init(api);
 
-            contentService = new ContentService<Page, PageField, Models.PageBase>(new ContentFactory(_services), Piranha.Data.EF.Module.Mapper);
+            contentService = new ContentService<Page, PageField, Models.PageBase>(new ContentFactory(_services));
 
             // Add media
             using (var stream = File.OpenRead("../../../Assets/HLD_Screenshot_01_mech_1080.png"))

--- a/test/Piranha.Tests/DataModelMapperTests.cs
+++ b/test/Piranha.Tests/DataModelMapperTests.cs
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) .NET Foundation and Contributors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ *
+ * https://github.com/piranhacms/piranha.core
+ *
+ */
+
+using Piranha.Data;
+using Piranha.Data.EF.Mapping;
+using Xunit;
+
+namespace Piranha.Tests;
+
+public class DataModelMapperTests
+{
+    private sealed class TestPage : Models.Page<TestPage> { }
+
+    private sealed class TestPost : Models.Post<TestPost> { }
+
+    private sealed class TestSiteContent : Models.SiteContent<TestSiteContent> { }
+
+    [Fact]
+    public void MapsPageDataToModel()
+    {
+        var id = Guid.NewGuid();
+        var imageId = Guid.NewGuid();
+        var page = new Page
+        {
+            Id = id,
+            Title = "Page title",
+            PageTypeId = "PageType",
+            Slug = "page-slug",
+            PrimaryImageId = imageId,
+            Excerpt = "Excerpt",
+            MetaIndex = true,
+            MetaFollow = false,
+            SortOrder = 2,
+            IsHidden = true,
+            Permissions = { new PagePermission { Permission = "Secret" } }
+        };
+        var model = new TestPage();
+
+        DataModelMapper.MapToModel(page, model);
+
+        Assert.Equal(id, model.Id);
+        Assert.Equal("Page title", model.Title);
+        Assert.Equal("PageType", model.TypeId);
+        Assert.Equal("page-slug", model.Slug);
+        Assert.Equal(imageId, model.PrimaryImage.Id);
+        Assert.Equal("Excerpt", model.Excerpt);
+        Assert.True(model.MetaIndex);
+        Assert.False(model.MetaFollow);
+        Assert.True(model.IsHidden);
+        Assert.Empty(model.Permissions);
+    }
+
+    [Fact]
+    public void MapsPageModelToDataWithoutOverwritingManagedCollections()
+    {
+        var created = new DateTime(2024, 1, 1);
+        var lastModified = new DateTime(2024, 2, 1);
+        var imageId = Guid.NewGuid();
+        var page = new Page
+        {
+            Created = created,
+            LastModified = lastModified,
+            ContentType = "Existing",
+            Permissions = { new PagePermission { Permission = "Keep" } }
+        };
+        var model = new TestPage
+        {
+            Id = Guid.NewGuid(),
+            Title = "Updated",
+            TypeId = "PageType",
+            Slug = "updated",
+            PrimaryImage = new Extend.Fields.ImageField { Id = imageId },
+            Created = DateTime.Now,
+            LastModified = DateTime.Now,
+            Permissions = { "Ignored" }
+        };
+
+        DataModelMapper.MapToData(model, page);
+
+        Assert.Equal(model.Id, page.Id);
+        Assert.Equal("Updated", page.Title);
+        Assert.Equal("PageType", page.PageTypeId);
+        Assert.Equal("updated", page.Slug);
+        Assert.Equal(imageId, page.PrimaryImageId);
+        Assert.Equal(created, page.Created);
+        Assert.Equal(lastModified, page.LastModified);
+        Assert.Equal("Existing", page.ContentType);
+        Assert.Single(page.Permissions);
+        Assert.Equal("Keep", page.Permissions[0].Permission);
+    }
+
+    [Fact]
+    public void MapsPostTaxonomies()
+    {
+        var categoryId = Guid.NewGuid();
+        var tagId = Guid.NewGuid();
+        var post = new Post
+        {
+            Id = Guid.NewGuid(),
+            Title = "Post title",
+            PostTypeId = "PostType",
+            BlogId = Guid.NewGuid(),
+            Category = new Category
+            {
+                Id = categoryId,
+                Title = "Category",
+                Slug = "category"
+            },
+            Tags =
+            {
+                new PostTag
+                {
+                    TagId = tagId,
+                    Tag = new Tag
+                    {
+                        Id = tagId,
+                        Title = "Tag",
+                        Slug = "tag"
+                    }
+                }
+            }
+        };
+        var model = new TestPost();
+
+        DataModelMapper.MapToModel(post, model);
+
+        Assert.Equal("PostType", model.TypeId);
+        Assert.Equal(categoryId, model.Category.Id);
+        Assert.Equal(Models.TaxonomyType.Category, model.Category.Type);
+        Assert.Single(model.Tags);
+        Assert.Equal(tagId, model.Tags[0].Id);
+        Assert.Equal(Models.TaxonomyType.Tag, model.Tags[0].Type);
+    }
+
+    [Fact]
+    public void MapsSitemapPermissions()
+    {
+        var page = new Page
+        {
+            Id = Guid.NewGuid(),
+            Slug = "child",
+            SortOrder = 1,
+            Permissions =
+            {
+                new PagePermission { Permission = "Admin" },
+                new PagePermission { Permission = "Editor" }
+            }
+        };
+
+        var item = DataModelMapper.Map(page);
+
+        Assert.Equal("/child", item.Permalink);
+        Assert.Equal(new[] { "Admin", "Editor" }, item.Permissions);
+    }
+
+    [Fact]
+    public void MapsSiteModelToDataWithoutOverwritingSiteSettings()
+    {
+        var site = new Site
+        {
+            SiteTypeId = "ExistingType",
+            InternalId = "main",
+            Hostnames = "example.com",
+            IsDefault = true,
+            ContentLastModified = new DateTime(2024, 1, 1)
+        };
+        var model = new TestSiteContent
+        {
+            Id = Guid.NewGuid(),
+            Title = "Site content",
+            TypeId = "IgnoredType"
+        };
+
+        DataModelMapper.MapToData(model, site);
+
+        Assert.Equal(model.Id, site.Id);
+        Assert.Equal("Site content", site.Title);
+        Assert.Equal("ExistingType", site.SiteTypeId);
+        Assert.Equal("main", site.InternalId);
+        Assert.Equal("example.com", site.Hostnames);
+        Assert.True(site.IsDefault);
+        Assert.Equal(new DateTime(2024, 1, 1), site.ContentLastModified);
+    }
+}


### PR DESCRIPTION
## Summary

This PR removes the AutoMapper dependency from `Piranha.Data.EF` and replaces the small internal mapping surface with explicit mapping methods. 

The goal is to reduce dependency surface area in the EF data layer and make the mappings easier to audit and maintain.

### Please Review!

## What changed

- Removed the `AutoMapper` package reference from `Piranha.Data.EF`.
- Removed the static `Module.Mapper` setup.
- Added an internal `DataModelMapper` for explicit data/model mappings.
- Updated content services and repositories to use explicit mapping.
- Added focused mapper parity tests.
- Updated existing tests that directly instantiated `ContentService`.

## Why

`Piranha.Data.EF` used AutoMapper only for a relatively small set of internal mappings. Replacing those mappings directly avoids future AutoMapper API churn, licensing considerations in newer AutoMapper versions, and dependency-related security maintenance.

This also makes important mapping behavior more visible, especially around fields that should intentionally not be overwritten, such as EF navigation properties, blocks, fields, permissions, timestamps, and translation collections.

## Caveat / API compatibility

This removes `IMapper` from `IContentServiceFactory.Create<TContent, TField, TModelBase>()`.

Before:

```csharp
Create<TContent, TField, TModelBase>(IMapper mapper)